### PR TITLE
Changing calc_events from looping over time_array to lenses

### DIFF
--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1837,10 +1837,12 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
         radius = 2 * blend_rad
         large_blends_idxs = _return_match_idxs(coords_lens, coords_static,
                                                radius)
+
         # Remove the source and lens
         large_blends_idxs = [i for i in large_blends_idxs if
                              bigpatch[i]['obj_id']
                              not in event[['obj_id_L', 'obj_id_S']]]
+
         # Calculate coordinates of all potential neighbors at the time of t0
         timei = event['t0']
         glat_blends_tmp = bigpatch[large_blends_idxs]['glat'] + timei * bigpatch[large_blends_idxs]['mu_b'] *masyr_to_degday  # deg

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -2471,7 +2471,7 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
         for num, line in enumerate(my_file):
             if 'obs_time' in line:
                 obs_time = line.split(',')[1]
-                obs_time = int(obs_time)
+                obs_time = float(obs_time)
                 break
 
     # Calculate time and separation at closest approach, add to table

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1635,7 +1635,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     speed_cut = 15  # mas / yr
     print('Speed Cut : %.1f mas/yr' % speed_cut)
     obs_time_yrs = obs_time / 365.25  # yrs
-    microlensing_radius = einstein_radius(100, 1, 20)  # mas
+    microlensing_radius = einstein_radius(1000, 1, 20)  # mas
     search_radius_mas = microlensing_radius + 2 * speed_cut * obs_time_yrs  # mas
     search_radius = search_radius_mas / 1000  # as
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1635,7 +1635,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     speed_cut = 15  # mas / yr
     print('Speed Cut : %.1f mas/yr' % speed_cut)
     obs_time_yrs = obs_time / 365.25  # yrs
-    microlensing_radius = einstein_radius(1000, 1, 20)  # mas
+    microlensing_radius = 2 * einstein_radius(250, 1, 20)  # mas
     search_radius_mas = microlensing_radius + 2 * speed_cut * obs_time_yrs  # mas
     search_radius = search_radius_mas / 1000  # as
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1678,9 +1678,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
 
     # Calculate the maximum speed that two stars headed directly for
     # each other would have to be to not be captured by the `radius_cut`
-    print('radius_cut = %.1f' % radius_cut)
     radius_cut_mas = radius_cut * 1000  # mas
-    print('radius_cut_mas = %.1f' % radius_cut_mas)
     obs_time_yrs = obs_time / 365.25  # yrs
     speed_cut = radius_cut_mas / (2 * obs_time_yrs)  # mas
     print('Speed Cut : %.1f mas/yr' % speed_cut)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1614,6 +1614,9 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
         disp = _return_angular_separation(l_t_lens, b_t_lens,
                                           l_t_sources, b_t_sources)
 
+        # cleanup
+        del [b_t_sources, l_t_sources, b_t_lens, l_t_lens]
+
         # Find the time at which each potential source and the potential lens
         # are closest to each other on the sky.
         idx_disp_min = np.argmin(disp, axis=0)
@@ -1850,13 +1853,13 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
         glat_blends_tmp = bigpatch[large_blends_idxs]['glat'] + \
                           timei * bigpatch[large_blends_idxs]['mu_b'] * masyr_to_degday  # deg
         glon_blends_tmp = bigpatch[large_blends_idxs]['glon'] + timei * (bigpatch[large_blends_idxs]['mu_lcosb'] / np.cos(np.radians(bigpatch[large_blends_idxs]['glat']))) * masyr_to_degday
-        coords_blend_tmp = SkyCoord(frame='galactic',
+        coords_blends_tmp = SkyCoord(frame='galactic',
                                     l=glon_blends_tmp * units.deg,
                                     b=glat_blends_tmp * units.deg)
 
         # Calculate the indices of stars that are within the blend radius
         # at the time of t0
-        blends_idxs_tmp = _return_match_idxs(coords_lens, coords_blend_tmp,
+        blends_idxs_tmp = _return_match_idxs(coords_lens, coords_blends_tmp,
                                              blend_rad)
         blends_idxs = [large_blends_idxs[idx] for idx in blends_idxs_tmp]
 
@@ -1886,7 +1889,7 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
         #   coords_blends = SkyCoord(frame='galactic',
         #                           l=glon_blends * units.deg,
         #                           b=glat_blends * units.deg)
-        coords_blends = coords_blend_tmp[blends_idxs_tmp]
+        coords_blends = coords_blends_tmp[blends_idxs_tmp]
         sep_LN = coords_lens.separation(coords_blends)
         sep_LN = (sep_LN.to(units.arcsec)) / units.arcsec
 
@@ -1898,6 +1901,9 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
         blend_sorc_obj_id.extend(tmp_sorc_id)
         blend_neigh_idx.extend(blends_idxs)
         sep_LN_list.extend(sep_LN.value.tolist())
+
+        # cleanup
+        del [coords_lens, coords_blends_tmp, coords_blends]
 
     # Convert our lists into arrays.
     blend_neigh_obj_id = np.array(blend_neigh_obj_id)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1390,6 +1390,7 @@ def calc_events(hdf5_file, output_root2,
     events_tmp = unique_events(events_tmp)
     events_final = Table(events_tmp)
     N_events = len(events_final)
+    print('Candidate events detected: ', N_events)
 
     if len(results_bl) != 0:
         blends_tmp = unique_blends(blends_tmp)
@@ -1405,7 +1406,6 @@ def calc_events(hdf5_file, output_root2,
     # Make log file
     ##########
     now = datetime.datetime.now()
-    radius_cut = radius_cut / 1000.0  # back to arcsec
     microlens_path = os.path.dirname(inspect.getfile(perform_pop_syn))
     microlens_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                              cwd=microlens_path).decode('ascii').strip()

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1796,6 +1796,7 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, ball_tree_static, time_array_T,
         # Loop over each fast star and it's static star matches
         for fast_lens_idx, bigpatch_match_idxs in enumerate(bigpatch_match_idxs_arr):
             # Skip if there are no matches:
+            bigpatch_match_idxs = np.atleast_1d(bigpatch_match_idxs)
             if len(bigpatch_match_idxs) == 0:
                 continue
 
@@ -1875,6 +1876,7 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, ball_tree_static, time_array_T,
         # Loop over each fast lens star and it's fast star matches
         for fast_lens_idx, flat_match_idxs in enumerate(flat_match_idxs_arr):
             # Extract the fast_match_idxs from the flattened match array
+            flat_match_idxs = np.atleast_1d(flat_match_idxs)
             fast_match_idxs = flat_to_fast_match_idxs(flat_match_idxs,
                                                       N_fast_stars)
 
@@ -2013,6 +2015,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     events_lens_arr = []
     blends_lens_arr = []
     for lens_idx0, source_idxs0 in enumerate(source_idxs_arr):
+        source_idxs0 = np.atleast_1d(source_idxs0)
 
         # Convert all idx lists into numpy arrays
         lens_idx1 = np.array(lens_idx0).astype(int)
@@ -2279,6 +2282,7 @@ def _calc_blends(bigpatch, ball_tree_static, events_lens, blend_rad):
         blends_idxs = _return_match_idxs(event['glon_L'],
                                          event['glat_L'],
                                          ball_tree_static, blend_rad)
+        blends_idxs = np.atleast_1d(blends_idxs)
 
         # Remove the source and lens
         blends_idxs = [i for i in blends_idxs if bigpatch[i]['obj_id']

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1537,6 +1537,10 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
     N_fast_stars = len(fast_idxs)
     print('%i fast stars' % N_fast_stars)
 
+    # If there are no fast stars, simply return what was received
+    if N_fast_stars == 0:
+        return source_idxs_arr
+
     # Find the coordinates of the fast stars at all times in time_array.
     # To significantly speed up this function, we will calculate the matches
     # for all times in time_array in one match. Then we will use fancy
@@ -1672,17 +1676,8 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                             l=bigpatch['glon'] * units.deg,
                             b=bigpatch['glat'] * units.deg)
 
-    # # Calculate the maximum speed that two stars headed directly for
-    # # each other would have to be to not be captured by the `radius_cut`
-    # speed_cut = 15  # mas / yr
-    # print('Speed Cut : %.1f mas/yr' % speed_cut)
-    # obs_time_yrs = obs_time / 365.25  # yrs
-    # microlensing_radius = 2 * einstein_radius(250, 1, 20)  # mas
-    # radius_mas = microlensing_radius + 2 * speed_cut * obs_time_yrs  # mas
-    # radius_cut = radius_mas / 1000  # as
-
-    # # Calculate the maximum speed that two stars headed directly for
-    # # each other would have to be to not be captured by the `radius_cut`
+    # Calculate the maximum speed that two stars headed directly for
+    # each other would have to be to not be captured by the `radius_cut`
     print('radius_cut = %.1f' % radius_cut)
     radius_cut_mas = radius_cut * 1000  # mas
     print('radius_cut_mas = %.1f' % radius_cut_mas)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1535,8 +1535,12 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
                                              search_radius)
 
     # Loop over each static star and it's fast star matches
-    counter = 0
+    fast_stars_counter = 0
+    new_apertures_counter = 0
     for static_idx, flat_match_idxs in enumerate(flat_match_idxs_arr):
+        # Skip if there are no matches:
+        if len(flat_match_idxs) == 0:
+            continue
         # Extract the fast_match_idxs from the flattened match array
         fast_match_idxs = flat_to_fast_match_idxs(flat_match_idxs,
                                                   N_fast_stars)
@@ -1553,20 +1557,23 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
                               if i not in source_idxs_arr[static_idx]]
         # If there are any fast star matches left...
         if len(fast_bigpatch_idxs) > 0:
+            fast_stars_counter += 1
             # Add the fast stars into the static star's
             # list of possible sources
             source_idxs_arr[static_idx] += fast_bigpatch_idxs
             # And for each fast star, add this loop's static star into
             # it's the fast star's list of possible sources
             for fast_bigpath_idx in fast_bigpatch_idxs:
-                counter += 1
+                new_apertures_counter += 1
                 source_idxs_arr[fast_bigpath_idx].append(static_idx)
 
         del [flat_match_idxs, fast_match_idxs, fast_bigpatch_idxs]
 
     del [b_t_fast, l_t_fast, coords_fast, flat_match_idxs_arr]
 
-    print('%i fast stars added to new lensing apertures' % counter)
+    print('%i fast stars added to '
+          '%i lensing apertures' % (fast_stars_counter,
+                                    new_apertures_counter))
     return source_idxs_arr
 
 
@@ -1626,6 +1633,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     # each other at the maximum possible speed to enter into a lens'
     # largest possible Einstein radius.
     speed_cut = 15  # mas / yr
+    print('Speed Cut : %.1f mas/yr' % speed_cut)
     obs_time_yrs = obs_time / 365.25  # yrs
     microlensing_radius = einstein_radius(100, 1, 20)  # mas
     search_radius_mas = microlensing_radius + 2 * speed_cut * obs_time_yrs  # mas

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -34,9 +34,9 @@ import os
 from sklearn import neighbors
 import itertools
 from multiprocessing import Pool
+import inspect
 import numpy.lib.recfunctions as rfn
 from popsycle import utils
-import inspect
 
 
 ##########

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1321,9 +1321,6 @@ def calc_events(hdf5_file, output_root2,
     b_array = np.array(hf['lat_bin_edges'])
     hf.close()
 
-    # Converts radius_cut from arcseconds into milliarcseconds
-    radius_cut *= 1000.0
-
     # Set up the multiprocessing
     pool = Pool(n_proc)
 
@@ -1401,7 +1398,6 @@ def calc_events(hdf5_file, output_root2,
     # Make log file
     ##########
     now = datetime.datetime.now()
-    radius_cut = radius_cut / 1000.0  # back to arcsec
     microlens_path = os.path.dirname(inspect.getfile(perform_pop_syn))
     microlens_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                              cwd=microlens_path).decode('ascii').strip()
@@ -1687,7 +1683,9 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
 
     # # Calculate the maximum speed that two stars headed directly for
     # # each other would have to be to not be captured by the `radius_cut`
+    print('radius_cut = %.1f' % radius_cut)
     radius_cut_mas = radius_cut * 1000  # mas
+    print('radius_cut_mas = %.1f' % radius_cut_mas)
     obs_time_yrs = obs_time / 365.25  # yrs
     speed_cut = radius_cut_mas / (2 * obs_time_yrs)  # mas
     print('Speed Cut : %.1f mas/yr' % speed_cut)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1845,7 +1845,8 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
 
         # Calculate coordinates of all potential neighbors at the time of t0
         timei = event['t0']
-        glat_blends_tmp = bigpatch[large_blends_idxs]['glat'] + timei * bigpatch[large_blends_idxs]['mu_b'] *masyr_to_degday  # deg
+        glat_blends_tmp = bigpatch[large_blends_idxs]['glat'] + \
+                          timei * bigpatch[large_blends_idxs]['mu_b'] * masyr_to_degday  # deg
         glon_blends_tmp = bigpatch[large_blends_idxs]['glon'] + timei * (bigpatch[large_blends_idxs]['mu_lcosb'] / np.cos(np.radians(bigpatch[large_blends_idxs]['glat']))) * masyr_to_degday
         coords_blend_tmp = SkyCoord(frame='galactic',
                                     l=glon_blends_tmp * units.deg,

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1827,7 +1827,9 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
     blend_neigh_idx = []
     sep_LN_list = []
 
+    # If multiple sources are around the same lens, loop over them
     for event in event_lbt:
+
         # Define the center of the blending disk (the lens)
         coords_lens = SkyCoord(frame='galactic',
                                l=event['glon_L'] * units.deg,

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1552,8 +1552,16 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
 
         disp = np.hypot(delta_b, delta_l)
         idx_disp_min = np.argmin(disp, axis=1)
-        sep = disp[np.arange(len(idx_disp_min)), idx_disp_min]
-        sep *= 3600 * 1000
+
+        lb_base = SkyCoord(frame='galactic',
+                           l=l_t_base[idx_disp_min] * units.deg,
+                           b=b_t_base[idx_disp_min] * units.deg)
+        lb_local = SkyCoord(frame='galactic',
+                           l=l_t_local[np.arange(len(idx_disp_min)), idx_disp_min] * units.deg,
+                           b=b_t_local[np.arange(len(idx_disp_min)), idx_disp_min] * units.deg)
+        sep = lb_base.separation(lb_local)
+        sep = (sep.to(units.arcsec)) / units.arcsec
+        sep = sep.value * 1000
 
         theta_E = einstein_radius(bigpatch[j]['mass'],
                                   bigpatch[j]['rad'],

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1831,20 +1831,6 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     events_llbb = np.hstack(events_lens_arr)
     blends_llbb = np.hstack(blends_lens_arr)
 
-    # Keep only unique events (not sure if this is still necessary)
-    if events_llbb is not None:
-        N_events0 = len(events_llbb)
-        events_llbb = unique_events(events_llbb)
-        N_events1 = len(events_llbb)
-        print('unique_events: %i -> %i events' % (N_events0, N_events1))
-
-    # Keep only unique blends (not sure if this is still necessary)
-    if blends_llbb is not None:
-        N_blends0 = len(blends_llbb)
-        blends_llbb = unique_blends(blends_llbb)
-        N_blends1 = len(blends_llbb)
-        print('unique_blends: %i -> %i blends' % (N_blends0, N_blends1))
-
     del [coords_static, source_idxs_arr]
     gc.collect()
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1819,8 +1819,15 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                 blends_lens_arr.append(blends_lens)
                 del blends_lens
 
-    events_llbb = np.hstack(events_lens_arr)
-    blends_llbb = np.hstack(blends_lens_arr)
+    if len(events_lens_arr) > 0:
+        events_llbb = np.hstack(events_lens_arr)
+    else:
+        events_llbb = None
+
+    if len(blends_lens_arr) > 0:
+        blends_llbb = np.hstack(blends_lens_arr)
+    else:
+        blends_llbb = None
 
     del [coords_static, source_idxs_arr]
     gc.collect()

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1689,7 +1689,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                 else:
                     blends_llbb = blends_lbt
 
-        del [event_lbt, blends_llbb]
+        del [event_lbt, blends_lbt]
 
     # Keep only unique events (not sure if this is still necessary)
     if events_llbb is not None:

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1878,11 +1878,17 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
 
     # Keep only unique events (not sure if this is still necessary)
     if events_llbb is not None:
+        N_events0 = len(events_llbb)
         events_llbb = unique_events(events_llbb)
+        N_events1 = len(events_llbb)
+        print('unique_events: %i -> %i events' % (N_events0, N_events1))
 
     # Keep only unique blends (not sure if this is still necessary)
     if blends_llbb is not None:
+        N_blends0 = len(blends_llbb)
         blends_llbb = unique_blends(blends_llbb)
+        N_blends1 = len(blends_llbb)
+        print('unique_blends: %i -> %i blends' % (N_blends0, N_blends1))
 
     del [coords_static, source_idxs_arr]
     gc.collect()
@@ -2464,7 +2470,7 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
     # NOTE: calc_closest_approach modifies the event table!
     # It trims out events that peak outside the survey range!
     N_events_original = len(event_tab)
-    print('Original candidate events: ', N_events_original)
+    print('Original candidate events (dark sources removed): ', N_events_original)
     u0, t0 = calc_closest_approach(event_tab, obs_time)
     N_events_survey = len(event_tab)
     print('Candidate events in survey window: ', N_events_survey)
@@ -2524,7 +2530,7 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
 
     line8 = 'OTHER INFORMATION' + '\n'
     line9 = str(t_1 - t_0) + ' : total runtime (s)' + '\n'
-    line10 = str(N_events_original) + ' : original candidate events ' + '\n'
+    line10 = str(N_events_original) + ' : original candidate events (dark sources removed)' + '\n'
     line11 = str(N_events_survey) + ' : candidate events in survey window' + '\n'
 
     line12 = 'FILES CREATED' + '\n'

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1492,7 +1492,7 @@ def _return_match_idxs(coords_centers, coords_surrounding, radius_cut):
 
 
 def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
-                                       speed_cut, radius, source_idxs_arr):
+                                       speed_cut, radius_cut, source_idxs_arr):
     """
     Find the fast stars that move into the search radii of a new star during
     the survey and populate that star's search population with the fast star.
@@ -1513,7 +1513,7 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
     speed_cut : float
         Minimum speed of a 'fast star'.
 
-    radius : float
+    radius_cut : float
         Radius around which each lens looks for stars that could be
         its microlensing source.
         'radius' must be provided in ARCSECONDS.
@@ -1568,7 +1568,7 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
     # Find all the fast stars that fall within the search radius
     # of a static star at any time in the survey
     flat_match_idxs_arr = _return_match_idxs(coords_static, coords_fast,
-                                             radius)
+                                             radius_cut)
 
     # Loop over each static star and it's fast star matches
     fast_stars_counter = 0

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1686,11 +1686,11 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                 else:
                     blends_llbb = blends_lbt
 
-    # Keep only unique events
+    # Keep only unique events (not sure if this is still necessary)
     if events_llbb is not None:
         events_llbb = unique_events(events_llbb)
 
-    # Keep only unique blends
+    # Keep only unique blends (not sure if this is still necessary)
     if blends_llbb is not None:
         blends_llbb = unique_blends(blends_llbb)
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -2131,7 +2131,7 @@ def _calc_event_cands_thetaE(bigpatch, theta_E, u, theta_frac, lens_id,
     Return
     ------
     events_lens : array
-        Lenses and sources pf a particular lens
+        Lenses and sources of a particular lens
 
     """
     # NOTE: adx is an index into lens_id or event_id (NOT bigpatch)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1711,14 +1711,18 @@ def _return_match_idxs(glon, glat, ball_tree, radius_cut):
         for each object in glon, glat
 
     """
+    # Support for either a list or a single point
     glon = np.atleast_1d(glon)
+    # BallTree requires a list of (lat, lon) in radians
     points = np.zeros((len(glon), 2))
     points[:, 0] = np.radians(glat)
     points[:, 1] = np.radians(glon)
+    # Convert radius_cut from arcseconds to radians
     radius_cut_rad = np.radians(radius_cut / 3600)
+    # Returns an array of arrays
     match_idxs = ball_tree.query_radius(points, radius_cut_rad)
 
-    # Return the first element if 'coords_centers' is a single point
+    # Return the first array if the positions are a single point
     if len(glon) == 1:
         match_idxs = match_idxs[0]
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1503,8 +1503,6 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
         # continue
         return
 
-    # bigpatch = bigpatch[:100000]
-
     t0 = time.time()
 
     # Create a static coordinate catalog of the stars without any motion
@@ -1516,17 +1514,13 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                                     nthneighbor=2)
     kdtree_cache = static_coord.cache['kdtree_sky']
 
-    # Set a cutoff speed above which stars will be searched or differently
-    speed_cut = 5
-    star_speeds = np.hypot(bigpatch['mu_b'], bigpatch['mu_lcosb'])
-    speed_cut_cond = star_speeds > speed_cut
-
     # Calculate the separation limit for two stars moving exactly toward
     # each other at the maximum possible speed to enter into a lens'
     # largest possible Einstein radius
+    speed_cut = 15
     obs_time_yrs = obs_time / 365.25
-    seplimit_as = einstein_radius(1000, .1, 20) + 2 * speed_cut * obs_time_yrs
-    seplimit = seplimit_as * units.arcsec / 1000
+    seplimit_mas = einstein_radius(100, 1, 20) + 2 * speed_cut * obs_time_yrs
+    seplimit = seplimit_mas * units.arcsec / 1000
 
     # Calculate the indices of stars that are within this
     # separation limit for all stars in bigpatch

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1689,6 +1689,8 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                 else:
                     blends_llbb = blends_lbt
 
+        del [event_lbt, blends_llbb]
+
     # Keep only unique events (not sure if this is still necessary)
     if events_llbb is not None:
         events_llbb = unique_events(events_llbb)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1504,6 +1504,8 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
                            l=l_t_fast * units.deg,
                            b=b_t_fast * units.deg)
 
+    del [b_t_fast, l_t_fast]
+
     # Define a convenience function for going from the
     # flattened fast_match_idx to the fast_idx of the star
     def flat_to_fast_match_idxs(fast_match_idxs, N_fast_stars):
@@ -1563,7 +1565,7 @@ def _add_fast_stars_to_source_idxs_arr(bigpatch, coords_static, time_array_T,
 
         del [flat_match_idxs, fast_match_idxs, fast_bigpatch_idxs]
 
-    del [b_t_fast, l_t_fast, coords_fast, flat_match_idxs_arr]
+    del [coords_fast, flat_match_idxs_arr]
 
     print('%i fast stars added to '
           '%i lensing apertures' % (fast_stars_counter,
@@ -1659,6 +1661,7 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
     t1 = time.time()
     print('Fast Stars Time: %.2fs' % (t1 - t0))
     t0 = time.time()
+
     # Loop through all of the stars,
     # checking to see if each one could be a lens to a surrounding star
     # Initialize events_llbb_arr and blends_llbb_arr.
@@ -1783,8 +1786,6 @@ def _calc_event_time_loop(llbb, hdf5_file, obs_time, n_obs, radius_cut,
                 blends_lbt_arr.append(blends_lbt)
                 del blends_lbt
 
-        gc.collect()
-
     events_llbb = np.hstack(events_lbt_arr)
     blends_llbb = np.hstack(blends_lbt_arr)
 
@@ -1897,7 +1898,6 @@ def _calc_event_cands_thetaE(bigpatch, theta_E, u, theta_frac, lens_id,
                                       t_event, usemask=False)
 
         del [sorc_table, lens_table]
-        gc.collect()
 
         return event_lbt
 
@@ -2010,7 +2010,6 @@ def _calc_blends(bigpatch, coords_static, event_lbt, blend_rad):
         # cleanup
         del [large_blends_idxs, b_blends_tmp, l_blends_tmp]
         del [coords_lens, coords_blends_tmp, coords_blends]
-        gc.collect()
 
     # Convert our lists into arrays.
     blend_neigh_obj_id = np.array(blend_neigh_obj_id)

--- a/popsycle/utils.py
+++ b/popsycle/utils.py
@@ -166,3 +166,43 @@ def execute(cmd, shell=False):
     stdout, stderr = process.communicate()
 
     return stdout, stderr
+
+
+def return_angular_separation(lon1, lat1, lon2, lat2):
+    """
+    Distance between two coordinates on the celestial sphere
+    using an adaptation of the the Haversine formula.
+    https://en.wikipedia.org/wiki/Haversine_formula
+
+    Parameters
+    ----------
+    lon1 : float
+        longitude of first coordinate, in degrees
+
+    lat1 : float
+        latitude of first coordinate, in degrees
+
+    lon2 : float
+        longitude of second coordinate, in degrees
+
+    lon2 : float
+        latitude of second coordinate, in degrees
+
+    Return
+    ------
+    sep : float
+        separation of two coordinates, in degrees
+
+    """
+    lon1, lat1 = np.radians(lon1), np.radians(lat1)
+    lon2, lat2 = np.radians(lon2), np.radians(lat2)
+
+    sdlon, cdlon = np.sin(lon2 - lon1), np.cos(lon2 - lon1)
+    slat1, slat2 = np.sin(lat1), np.sin(lat2)
+    clat1, clat2 = np.cos(lat1), np.cos(lat2)
+
+    num1 = clat2 * sdlon
+    num2 = clat1 * slat2 - slat1 * clat2 * cdlon
+    denominator = slat1 * slat2 + clat1 * clat2 * cdlon
+    sep = np.arctan2(np.hypot(num1, num2), denominator) * 180 / np.pi
+    return sep


### PR DESCRIPTION
**Code Description**
This rewrite of `calc_events` is an implementation of the brainstorming made at the January BAMM meeting. The idea was to avoid reconstruction of the kdtree at each time in the survey's time_array. The central idea is to treat slow stars and fast stars differently.

Slow stars will be near the same surrounding stars throughout any reasonably long microlensing survey (< 10 yrs). Therefore we can compare each slow star to it's surrounding stars at t0 = 0, or what I'm calling the static catalog. We loop through each star in the catalog, and ask what stars are around it in the static catalog within the search radius `radius_cut`. To calculate what the `speed_cut` is between slow stars and fast stars, we calculate:
`speed_cut = radius_cut_mas / (2 * obs_time_yrs)`
`speed_cut = 91.3 mas/yr` for `radius_cut = 0.5` and `obs_time_yrs = 10`.

This method finds all microlensing events with Einstein radius less than `radius_cut`.

The code loops over all of the stars in the catalog, asking if each one could be a lens to the stars in it's search radius. Through a series of cuts, it only applies expensive calculations to extremely close stars that are behind the lens. Then the event parameters and blends are calculated for the event.

Fast stars are pre-treated in two ways.  First, before the main loop begins, the code queries the location of fast stars against the static catalog for every time in the survey's time_array. If at any point in the survey a fast star moves into the search radius of a different static star, (1) the fast star is added to the list of possible microlensing sources of that static star, and (2) the static star is added the list of possible microlensing sources of the fast star. Second, every fast star is compared to the location of every other fast star at every time step in the survey. If either fast star is within the search radius of another fast star at any time, the sub-steps listed above are down for each fast star. Once this has been done for all fast stars, the main search loop proceeds.

**Performance Results**
Tables showing identical events detected and speed ups for single sets of PopSyCLE parameters [shown here](https://jluastro.atlassian.net/wiki/spaces/MIC/pages/980516865/neighbor+matching+branch+results).
To highlight the speed-up in `calc_events`:

_Small_
longitude 1.250000
latitude -2.650000
surveyArea 0.00100
master : 326.1s
neighbor_matching : 245.8s
~25% reduction

_Medium_
longitude 1.250000
latitude -2.650000
surveyArea 0.00330
master : 1183.2s
neighbor_matching : 817.1s
31% reduction

_Large_
longitude 2.000000
latitude 1.000000
surveyArea 0.33000
master : s
neighbor_matching : s
% reduction

Plots showing the speed ups across a range of PopSyCLE parameters [shown here](https://jluastro.atlassian.net/wiki/spaces/MIC/pages/990150668/neighbor+matching+performance+across+PopSyCLE+parameters).

**Additional Changes**
- Added number of events found to log files for `calc_events` and `refine_events`
- Renamed variables to reflect the change in loop structure
- Removed converting radius_cut from arcseconds to mili-arcseconds in place