### PR TITLE
Functions to manipulate lightcurves, hdf5 analysis utilities, and bug fixes

### DIFF
--- a/popsycle/analysis.py
+++ b/popsycle/analysis.py
@@ -1,0 +1,115 @@
+import pandas as pd
+import numpy as np
+import h5py
+import pylab as plt
+
+import utils
+from popsycle import synthetic
+import time
+
+def get_star_system_pos_mag(hdf5_file, filt='ubv_I'):
+    """
+    Return a table with lists of star systems and their RA, Dec, z position,
+    and system apparent magnitude. This is useful for making stellar density maps,
+    computing microlens event occurrence rates, etc. Columns will also be
+    returned containing the
+
+    Parameters
+    ----------
+    hdf5_file : str
+        Name of the H5 file output from perform_pop_syn.
+    filt : str
+        filter to use to calculate the apparent magnitude
+
+    Returns
+    -------
+    df_final : pandas dataframe
+        Columns include:
+            ['obj_id', 'exbv', 'glat', 'glon', 'rad', 'isMultiple',
+            'N_companions', 'rem_id', 'm_ubv_I_app']
+
+        where the magnitude column is the apparent system magnitude
+        in the designated filter.
+    """
+    # Load up the H5 file with star systems.
+    hf = h5py.File(hdf5_file, 'r')
+
+    # Trim keys down to valid patch keys (e.g. "l0b0").
+    orig_keys = hf.keys()   # Patch keys.
+    field_keys = []
+    for key in list(orig_keys)[:-2]:
+        if key.startswith('l'):
+            field_keys.append(key)
+
+    ext_law = 'Damineli16'
+    start_time = time.time()
+    df_final = None
+
+    # Loop through the fields and aggregate the stars.
+    for k in field_keys:
+        patch = np.array(hf[k])
+
+        if len(patch) > 0:
+            # Make a Pandas data frame. Faster to work with and index against with companions.
+            patch_df = pd.DataFrame(data=patch, columns=np.dtype(patch[0]).names)
+            patch_df.set_index(['obj_id'])
+
+            # Memory management
+            del patch
+            patch_df.drop(columns=['px', 'py', 'pz', 'vx', 'vy', 'vz',
+                                   'vr', 'mu_b', 'mu_lcosb',
+                                   'zams_mass', 'mass', 'systemMass',
+                                   'age', 'popid', 'mbol', 'grav', 'teff', 'feh', 'mbol'],
+                          inplace=True)
+
+            # Make flux column.
+            patch_df['m_' + filt + '_app'] = synthetic.calc_app_mag(patch_df['rad'],
+                                                                    patch_df[filt],
+                                                                    patch_df['exbv'],
+                                                                    synthetic.filt_dict[filt][ext_law])
+
+            # More memory management. Drop absolute mag columns
+            patch_df.drop(patch_df.filter(regex='^ubv').columns, axis=1, inplace=True)
+
+            # Save to final stacked dataframe (all stars)
+            if df_final is None:
+                df_final = patch_df
+            else:
+                df_final = pd.concat([df_final, patch_df])
+
+    del hf
+
+    stop_time = time.time()
+    print(f'Run time = {stop_time - start_time} sec')
+
+    return df_final
+
+def count_stars_hdf5(hdf5_file, filt='ubv_I', mag_threshold=21):
+    """
+    Finds the number of stars in the field brighter than a certain mag.
+    Assumes binary/multiple stars are blended.
+
+    Parameters
+    ----------
+    hdf5_file : str
+        Filename of an hdf5 file.
+
+    filt : str
+        Ubv filter in PopSyCLE ubv_(U, B, V, I, R, J, H, K).
+        Default is ubv_I.
+
+    mag_threshold: float
+        Magnitude below which we count the number of stars.
+
+    Returns
+    -------
+    stars_above_threshold : float
+        Number of stars brighter than mag threshold (1e-6).
+    """
+    df_all_stars = get_star_system_pos_mag(hdf5_file, filt=filt)
+
+    # Get good stars above our magnitude threshold.
+    gdx = np.where(df_all_stars['m_' + filt + '_app'] < mag_threshold)[0]
+    N_stars = len(gdx)
+
+    return N_stars

--- a/popsycle/analysis.py
+++ b/popsycle/analysis.py
@@ -3,11 +3,12 @@ import numpy as np
 import h5py
 import pylab as plt
 
-import utils
+from popsycle import utils
 from popsycle import synthetic
 import time
+import os
 
-def get_star_system_pos_mag(hdf5_file, filt='ubv_I'):
+def get_star_system_pos_mag(hdf5_file, filt='ubv_I', recalc=True):
     """
     Return a table with lists of star systems and their RA, Dec, z position,
     and system apparent magnitude. This is useful for making stellar density maps,
@@ -31,6 +32,15 @@ def get_star_system_pos_mag(hdf5_file, filt='ubv_I'):
         where the magnitude column is the apparent system magnitude
         in the designated filter.
     """
+    outfile = hdf5_file.replace('.h5', '_stars_posmag.pkl')
+
+    if os.path.exists(outfile) and recalc == False:
+        start_time = time.time()
+        df_final = pd.read_pickle(outfile)
+        stop_time = time.time()
+        print(f'get_star_system_pos_mag: Run time = {stop_time - start_time} sec with recalc=False')
+        return df_final
+
     # Load up the H5 file with star systems.
     hf = h5py.File(hdf5_file, 'r')
 
@@ -43,10 +53,13 @@ def get_star_system_pos_mag(hdf5_file, filt='ubv_I'):
 
     ext_law = 'Damineli16'
     start_time = time.time()
-    df_final = None
+
+    list_of_df = []
 
     # Loop through the fields and aggregate the stars.
+    print('Countint stars in patches: ', end="")
     for k in field_keys:
+        print(f'{k}, ', end="")
         patch = np.array(hf[k])
 
         if len(patch) > 0:
@@ -71,16 +84,17 @@ def get_star_system_pos_mag(hdf5_file, filt='ubv_I'):
             # More memory management. Drop absolute mag columns
             patch_df.drop(patch_df.filter(regex='^ubv').columns, axis=1, inplace=True)
 
-            # Save to final stacked dataframe (all stars)
-            if df_final is None:
-                df_final = patch_df
-            else:
-                df_final = pd.concat([df_final, patch_df])
+            # Save to list of all data frames (to be concatenatted later)
+            list_of_df.append(patch_df)
 
-    del hf
+    df_final = pd.concat(list_of_df)
+    del list_of_df
 
     stop_time = time.time()
-    print(f'Run time = {stop_time - start_time} sec')
+    print()
+    print(f'get_star_system_pos_mag: Run time = {stop_time - start_time} sec')
+
+    df_final.to_pickle(outfile)
 
     return df_final
 

--- a/popsycle/binary_utils.py
+++ b/popsycle/binary_utils.py
@@ -2,6 +2,8 @@ import numpy as np
 import warnings
 from astropy.table import Table, Column
 from ast import literal_eval
+import h5py
+import pandas as pd
 
 
 def add_magnitudes(mags):
@@ -299,13 +301,16 @@ def cut_Mruns(t_prim, t_comp_rb, t_comp_rb_mp, min_mag, delta_m_cut, u0_cut, ubv
 
     return t_both_mcut, t_both_mcut_one_peak, t_multiples_mcut_multi_peak
 
-def make_bhs_single(hdf5_file, hdf5_comp_file, bh_binary_frac = 0.1, new_hdf5_file = None, new_hdf5_file_comp = None):
+def make_bhs_single(hdf5_file, hdf5_comp_file, bh_binary_frac = 0.1, phots = ['ubv_I', 'ubv_K', 'ubv_J', 'ubv_U', 'ubv_R', 'ubv_B', 'ubv_V', 'ubv_H'],
+                    new_hdf5_file = None, new_hdf5_file_comp = None):
     """
     This makes some fraction of BHs singles.
     Currently no binary star evolution, so all BHs end up in binaries.
     We drop the companions from the companion table and set the BH parameters
     to those of a single BH.
     These are saved to a new file.
+
+    To be run after perform_pop_syn.
 
     Parameters
     ----------
@@ -318,6 +323,11 @@ def make_bhs_single(hdf5_file, hdf5_comp_file, bh_binary_frac = 0.1, new_hdf5_fi
     bh_binary_frac : float
         Binary fraction to be kept of BHs.
         Default is 0.1.
+
+    phots : list of str
+        Photometry values to be made nan for BHs.
+        Should include all photometry values in table.
+        Default is all those in ubv system.
 
     new_hdf5_file : str or None
         New hdf5 file name.

--- a/popsycle/binary_utils.py
+++ b/popsycle/binary_utils.py
@@ -299,6 +299,88 @@ def cut_Mruns(t_prim, t_comp_rb, t_comp_rb_mp, min_mag, delta_m_cut, u0_cut, ubv
 
     return t_both_mcut, t_both_mcut_one_peak, t_multiples_mcut_multi_peak
 
+def make_bhs_single(hdf5_file, hdf5_comp_file, bh_binary_frac = 0.1, new_hdf5_file = None, new_hdf5_file_comp = None):
+    """
+    This makes some fraction of BHs singles.
+    Currently no binary star evolution, so all BHs end up in binaries.
+    We drop the companions from the companion table and set the BH parameters
+    to those of a single BH.
+    These are saved to a new file.
+
+    Parameters
+    ----------
+    hdf5_file : str
+        File name of hdf5 file to modify.
+
+    hdf5_comp_file : str
+        File name of hdf5 companion file to modify.
+
+    bh_binary_frac : float
+        Binary fraction to be kept of BHs.
+        Default is 0.1.
+
+    new_hdf5_file : str or None
+        New hdf5 file name.
+        Default is None which saves it as 
+        hdf5_file[:-3] + '_{}_bhb_frac.h5'.format(bh_binary_frac).
+        
+    new_hdf5_file_comp : str or None
+        New hdf5 file name.
+        Default is None which saves it as
+        hdf5_comp_file[:-3] + '_{}_bhb_frac.h5'.format(bh_binary_frac).
+    """
+    
+    tmp_prim = h5py.File(hdf5_file, 'r')
+    keys = tmp_prim.keys()  
+    tmp_comp = h5py.File(hdf5_comp_file, 'r')
+    keys_comp = tmp_comp.keys()
+
+    if new_hdf5_file is None:
+        new_hdf5_file = hdf5_file[:-3] + '_{}_bhb_frac.h5'.format(bh_binary_frac)
+    if new_hdf5_file_comp is None:
+        new_hdf5_file_comp = hdf5_comp_file[:-3] + '_{}_bhb_frac.h5'.format(bh_binary_frac)
+
+    prim_copy = h5py.File(new_hdf5_file, 'w')
+    prim_copy[list(keys)[-2]] = tmp_prim[list(keys)[-2]][:]
+    prim_copy[list(keys)[-1]] = tmp_prim[list(keys)[-1]][:]
+    prim_copy.close()
+    
+    comp_copy = h5py.File(new_hdf5_file_comp, 'w')
+    comp_copy[list(keys)[-2]] = tmp_comp[list(keys)[-2]][:]
+    comp_copy[list(keys)[-1]] = tmp_comp[list(keys)[-1]][:]
+    comp_copy.close()
+
+    del tmp_prim
+    del tmp_comp
+
+    for i in list(keys)[1:-2]:
+        if i[0] == 'l':
+            prim = pd.read_hdf(hdf5_file, i).set_index(['obj_id'])
+            bh_prim = prim[prim['rem_id'] == 103]
+            #idxs of bhs that will be made single
+            bh_prim_singlify_idxs = np.random.choice(bh_prim.index, size = int(len(bh_prim)*(1-bh_binary_frac)), replace = False)
+            
+            bh_prim.loc[bh_prim_singlify_idxs, ('isMultiple')] = 0
+            bh_prim.loc[bh_prim_singlify_idxs, ('N_companions')] = 0
+            bh_prim.loc[bh_prim_singlify_idxs, ('systemMass')] = bh_prim.loc[bh_prim_singlify_idxs, ('mass')]
+            # set photometry to nan
+            for phot in phots:
+                bh_prim.loc[bh_prim_singlify_idxs, (phot)] = np.nan
+    
+            prim[prim['rem_id'] == 103] = bh_prim
+            
+            comp = pd.read_hdf(hdf5_comp_file, i).set_index(['system_idx'])
+            comp.drop(bh_prim_singlify_idxs)
+
+            with h5py.File(new_hdf5_file, 'r+') as prim_hdf5:
+                prim_np = prim.reset_index().to_numpy()
+                prim_hdf5.create_dataset(i, data=prim_np)
+
+            with h5py.File(new_hdf5_file_comp, 'r+') as comp_hdf5:
+                comp_np = comp.reset_index().to_numpy()
+                comp_hdf5.create_dataset(i, data=comp_np)
+
+    return
 
 
 

--- a/popsycle/lightcurves.py
+++ b/popsycle/lightcurves.py
@@ -1,0 +1,402 @@
+import pdb
+
+import numpy as np
+from bagle import model
+from astropy.coordinates import SkyCoord
+from astropy import units as unit
+from astropy.table import Table
+from popsycle import synthetic, binary_utils
+from multiprocessing import Pool, Value, Lock
+
+# def get_used_lightcurve_companions(event_table, comp_table, lcurve_table):
+# TODO: Finish this... not working at all yet.
+#     """Trim the companions and lightcurve tables down to just those that
+#     were involved in the 'used_lightcurve'. This is useful for ensuring you will
+#     only have one lightcurve per event in the event table. Get rid of all
+#     the irrelevant companions that only contribute blend flux.
+#
+#     Parameters
+#     ----------
+#     event_table : astropy.table.Table
+#     comp_table : astropy.table.Table
+#     lcurve_table : astropy.table.Table
+#
+#     Returns
+#     -------
+#
+#     """
+#     # Set event table index for easier cross-matching.
+#     event_table_df = event_table.to_pandas().set_index(['obj_id_L', 'obj_id_S'], drop=False)
+#
+#     # Convert other tables to pandas.
+#     lcurv_table_df = lcurve_table.to_pandas()
+#     comps_table_df = comp_table.to_pandas()
+#
+#     # Group lightcurves associated with the same event.
+#     grouped_lcurv = lcurv_table_df.groupby(['obj_id_L', 'obj_id_S'])
+#
+#     # Filter each group to just the companions used in the lightcurve.
+#     # Should be 1 lens companion for PSBL, 1 source companion for BSPL, 1 lens + 1 source for BSBL
+#     lcurv_used = lcurv_table_df.loc[grouped_lcurv['used_lightcurve'].idxmax()]
+#
+#     # Clean up columns that should be ints not floats and set index.
+#     lcurv_used['obj_id_L'] = lcurv_used['obj_id_L'].astype('int')
+#     lcurv_used['obj_id_S'] = lcurv_used['obj_id_S'].astype('int')
+#     lcurv_used.set_index(['obj_id_L', 'obj_id_S'], inplace=True)
+#
+#     comps_table_df['companion_idx'] = comps_table_df['companion_idx'].astype('float')
+#
+#     # Group the companions by the index for easier access.
+#     grouped_comps = comps_table_df.groupby(['obj_id_L', 'obj_id_S'])
+#
+#     def f_is_used_companion(group):
+#         lcurve_grp = lcurv_used.loc[[group['obj_id_L'], group['obj_id_S']]]
+#         group['companion_idx'] == lcurve_grp['companion_id_L']
+#
+#     in_used = grouped_comps.
+#
+#     grouped_comps_used = grouped_comps.loc[]
+#
+#     for i in range(len(event_table_df)):
+#         event_i = Table.from_pandas(event_table_df.iloc[[i]]) # return astropy table, not series
+#         index_i = event_table_df.index[i]
+#
+#         try:
+#             # Get the used lightcurve row.
+#             lcurve_i = lcurv_used.loc[index_i]
+#
+#             # Get the individual companions associated with this used lightcurve.
+#             comps_i_all = grouped_comps.get_group(index_i)
+#             comps_i = comps_i_all.loc[(comps_i_all['companion_idx'] == lcurve_i['companion_id_L']) |
+#                                       (comps_i_all['companion_idx'] == lcurve_i['companion_id_S'])]
+#             comps_i = Table.from_pandas(comps_i)
+#
+#         except KeyError:
+#             comps_i = None
+#
+#     return
+
+
+def get_bagle_model_list(event_table, comp_table, lcurve_table,
+                         photometric_system, filter_name, red_law, n_multi_proc=6):
+    """
+    Create BAGLE model instances for table of events.
+
+    Parameters
+    ----------
+    event_table : astropy.table.Table
+        Event table from synthetic.py refine_events.
+
+    comp_table : astropy.table.Table
+        Companions table that contains all lens or source companions for the events table.
+
+    lcurve_table : astropy.table.Table
+        Lightcurves generated for the binary events (from refine_binary_events). This is needed
+        to figure out which of the companions (in the case of triples) is used in advance.
+
+    photometric_system : str
+        Name of the photometric system, i.e. 'ubv'.
+
+    filter_name : str
+        Name of filter associated with photometric system, i.e. 'I'.
+
+    red_law : str
+        Name of reddening law in filt_dict list above, i.e. 'Damineli16'.
+
+    Returns
+    -------
+    A list of BAGLE model instances.
+
+    """
+    # Set event table index for easier cross-matching.
+    event_table_df = event_table.to_pandas().set_index(['obj_id_L', 'obj_id_S'], drop=False)
+
+    # Convert other tables to pandas.
+    lcurv_table_df = lcurve_table.to_pandas()
+    comps_table_df = comp_table.to_pandas()
+
+    # Group lightcurves associated with the same event.
+    grouped_lcurv = lcurv_table_df.groupby(['obj_id_L', 'obj_id_S'])
+
+    # Filter each group to just the companions used in the lightcurve.
+    # Should be 1 lens companion for PSBL, 1 source companion for BSPL, 1 lens + 1 source for BSBL
+    lcurv_used = lcurv_table_df.loc[grouped_lcurv['used_lightcurve'].idxmax()]
+
+    # Clean up columns that should be ints not floats and set index.
+    lcurv_used['obj_id_L'] = lcurv_used['obj_id_L'].astype('int')
+    lcurv_used['obj_id_S'] = lcurv_used['obj_id_S'].astype('int')
+    lcurv_used.set_index(['obj_id_L', 'obj_id_S'], inplace=True)
+
+    comps_table_df['companion_idx'] = comps_table_df['companion_idx'].astype('float')
+
+    # Group the companions by the index for easier access.
+    grouped_comps = comps_table_df.groupby(['obj_id_L', 'obj_id_S'])
+
+    # Split up the events and companions for use in multiprocessing
+    inputs = np.empty(len(event_table), dtype=object)
+
+    for i in range(len(event_table_df)):
+        event_i = Table.from_pandas(event_table_df.iloc[[i]]) # return astropy table, not series
+        index_i = event_table_df.index[i]
+
+        try:
+            # Get the used lightcurve row.
+            lcurve_i = lcurv_used.loc[index_i]
+
+            # Get the individual companions associated with this used lightcurve.
+            comps_i_all = grouped_comps.get_group(index_i)
+            comps_i = comps_i_all.loc[(comps_i_all['companion_idx'] == lcurve_i['companion_id_L']) |
+                                      (comps_i_all['companion_idx'] == lcurve_i['companion_id_S'])]
+            comps_i = Table.from_pandas(comps_i)
+
+        except KeyError:
+            comps_i = None
+
+        inputs[i] = [event_i, comps_i, photometric_system, filter_name, red_law]
+
+    if n_multi_proc > 1:
+        # Set up the multiprocessing
+        pool = Pool(n_multi_proc)
+
+        # Generate model instances for all the events.
+        results = pool.starmap(get_bagle_model, inputs)
+        pool.close()
+        pool.join()
+
+        all_models = results
+    else:
+        all_models = []
+        for i in range(len(inputs)):
+            all_models.append( get_bagle_model(*inputs[i]) )
+
+    return all_models
+
+
+def get_bagle_model(event, companions, photometric_system, filter_name, red_law):
+    """
+    Get a BAGLE model instance for a single event (and its associated companions).
+
+    Parameters
+    ----------
+    event : astropy.table.Table
+        A row from an astropy Table of events. Usually this is the produce of refine_events
+        and refine_binary_events(). The length of the table should be 1.
+
+    companions : astropy.table.Table
+        A table of the companions associated with the above event. This can be None if
+        no binaries were simulated. Note, the companions should only be those needed
+        to generate the event. If an event has triples involved, the irrelevant (or less
+        important) companions should be trimmed first.
+
+    photometric_system : str
+
+    filter_name : str
+
+    red_law : str
+
+    Returns
+    -------
+
+    """
+    event = event[0]
+
+    model_name, parameter_dict = get_bagle_model_name_and_params(event, companions,
+                                                                 photometric_system, filter_name, red_law)
+
+    mod_class = getattr(model, model_name)
+    mod = mod_class(**parameter_dict)
+
+    return mod
+
+
+def get_bagle_model_name_and_params(event, companions, photometric_system, filter_name, red_law):
+    """
+    For a single event and its associated companions, get the BAGLE model name
+    and parameters (in a dictionary).
+
+    Parameters
+    ----------
+    event : astropy.table.Table
+        A row from an astropy Table of events. Usually this is the produce of refine_events
+        and refine_binary_events(). The length of the table should be 1.
+
+    companions : astropy.table.Table
+        A table of the companions associated with the above event. This can be None if
+        no binaries were simulated. Note, the companions should only be those needed
+        to generate the event. If an event has triples involved, the irrelevant (or less
+        important) companions should be trimmed first.
+
+    photometric_system : str
+
+    filter_name : str
+
+    red_law : str
+
+    Returns
+    -------
+    model_name : str
+        Model name.
+
+    parameter_dict : dict
+        Dictionary of parameters (both fit and fixed).
+    """
+    # Determine the class of model to use.
+    multi_L = event['isMultiple_L']
+    multi_S = event['isMultiple_S']
+
+    if multi_L == 1 and multi_S == 1:
+        event_type = 'BSBL'
+    elif multi_L == 1 and multi_S == 0:
+        event_type = 'PSBL'
+    elif multi_L == 0 and multi_S == 1:
+        event_type = 'BSPL'
+    else:
+        event_type = 'PSPL'
+
+    # Get the lens and source ID numbers.
+    obj_id_L = event['obj_id_L']
+    obj_id_S = event['obj_id_S']
+
+    # Get the coordinates of this event.
+    L_coords = SkyCoord(l=event['glon_L'] * unit.degree,
+                        b=event['glat_L'] * unit.degree,
+                        pm_l_cosb=event['mu_lcosb_L'] * unit.mas / unit.year,
+                        pm_b=event['mu_b_L'] * unit.mas / unit.year, frame='galactic')
+    S_coords = SkyCoord(l=event['glon_S'] * unit.degree,
+                        b=event['glat_S'] * unit.degree,
+                        pm_l_cosb=event['mu_lcosb_S'] * unit.mas / unit.year,
+                        pm_b=event['mu_b_S'] * unit.mas / unit.year, frame='galactic')
+
+    raL = L_coords.icrs.ra.value  # Lens R.A.
+    decL = L_coords.icrs.dec.value  # Lens dec
+    muL = np.array([L_coords.icrs.pm_ra_cosdec.value, L_coords.icrs.pm_dec.value])  # lens proper motion mas/year
+    muS = np.array([S_coords.icrs.pm_ra_cosdec.value, S_coords.icrs.pm_dec.value])  # source proper motion mas/year
+
+    if event_type == 'PSPL':
+        model_name = 'PSPL_PhotAstrom_Par_Param1'
+
+        mL = event['mass_L']  # Msun (Primary lens current mass)
+        t0 = event['t0']  # mjd
+        xS0 = np.array([0, 0])  # arbitrary offset (arcsec)
+        beta = event['u0'] * event['theta_E']  # mas
+        dL = event['rad_L'] * 10 ** 3  # Distance to lens
+        dS = event['rad_S'] * 10 ** 3  # Distance to source
+        mag_src = [event['%s_%s_app_S' % (photometric_system, filter_name)]]
+        b_sff = [event['f_blend_%s' % filter_name]]
+
+        parameter_dict = {'raL': raL, 'decL': decL, 'mL': mL,
+                          't0': t0, 'beta': beta, 'dL': dL, 'dL_dS': dL / dS,
+                          'xS0_E': xS0[0], 'xS0_N': xS0[1],
+                          'muL_E': muL[0], 'muL_N': muL[1], 'muS_E': muS[0], 'muS_N': muS[1],
+                          'b_sff': b_sff, 'mag_src': mag_src}
+
+    if event_type == 'PSBL':
+        model_name = 'PSBL_PhotAstrom_Par_Param7'
+
+        # There should only be a single lens companion.
+        comp_idxs_L = np.where(companions['prim_type'] == b"L")[0]
+
+        if len(comp_idxs_L) > 1:
+            raise RuntimeError('Found too many lens companions. Triples not supported.')
+        else:
+            comp_idx_L = comp_idxs_L[0]
+
+        mLp = event['mass_L']  # msun (Primary lens current mass)
+        mLs = companions['mass'][comp_idx_L]  # msun (Companion lens current mass)
+        t0_p = event['t0']  # mjd
+        xS0 = np.array([0, 0])  # arbitrary offset (arcsec)
+        beta_p = event['u0'] * event['theta_E']  # 5.0
+        dL = event['rad_L'] * 10 ** 3  # Distance to lens
+        dS = event['rad_S'] * 10 ** 3  # Distance to source
+        sep = companions['sep'][comp_idx_L]  # mas (separation between primary and companion)
+        alpha = companions['alpha'][comp_idx_L]
+        mag_src = [event['%s_%s_app_S' % (photometric_system, filter_name)]]
+        b_sff = [event['f_blend_%s' % filter_name]]  # ASSUMES ALL BINARY LENSES ARE BLENDED
+
+        parameter_dict = {'raL': raL, 'decL': decL,
+                          'mLp': mLp, 'mLs': mLs, 't0_p': t0_p,
+                          'xS0_E': xS0[0], 'xS0_N': xS0[1], 'beta_p': beta_p,
+                          'muL_E': muL[0], 'muL_N': muL[1], 'muS_E': muS[0], 'muS_N': muS[1],
+                          'dL': dL, 'dS': dS, 'sep': sep,
+                          'alpha': alpha, 'mag_src': mag_src, 'b_sff': b_sff}
+
+    if event_type == 'BSPL':
+        model_name = 'BSPL_PhotAstrom_Par_Param1'
+
+        # There should only be a single source companion.
+        comp_idxs_S = np.where(companions['prim_type'] == b"S")[0]
+
+        if len(comp_idxs_S) > 1:
+            raise RuntimeError('Found too many source companions. Triples not supported.')
+        else:
+            comp_idx_S = comp_idxs_S[0]
+
+        f_i = synthetic.filt_dict[photometric_system + '_' + filter_name][red_law]
+        abs_mag_sec = companions['m_%s_%s' % (photometric_system, filter_name)][comp_idx_S]
+
+        mL = event['mass_L']  # msun (Lens current mass)
+        t0_p = event['t0']  # mjd
+        beta_p = event['u0'] * event['theta_E']  # 5.0
+        dL = event['rad_L'] * 10 ** 3  # Distance to lens
+        dL_dS = dL / (event['rad_S'] * 10 ** 3)  # Distance to lens/Distance to source
+        xS0 = np.array([0, 0])  # arbitrary offset (arcsec)
+        sep = companions['sep'][comp_idx_S]  # mas (separation between primary and companion)
+        alpha = companions['alpha'][comp_idx_S]
+        mag_src_sec = [synthetic.calc_app_mag(event['rad_S'], abs_mag_sec, event['exbv_S'], f_i)]
+        mag_src_pri = [binary_utils.subtract_magnitudes(
+            event['%s_%s_app_S' % (photometric_system, filter_name)], mag_src_sec)]
+        b_sff = [event['f_blend_%s' % filter_name]]  # ASSUMES THAT SOURCE BINARIES ARE BLENDED
+
+        parameter_dict = {'raL': raL, 'decL': decL, 'mL': mL,
+                          't0': t0_p, 'beta': beta_p, 'dL': dL, 'dL_dS': dL_dS,
+                          'xS0_E': xS0[0], 'xS0_N': xS0[1],
+                          'muL_E': muL[0], 'muL_N': muL[1], 'muS_E': muS[0], 'muS_N': muS[1],
+                          'sep': sep, 'alpha': alpha,
+                          'mag_src_pri': mag_src_pri, 'mag_src_sec': mag_src_sec, 'b_sff': b_sff}
+
+    if event_type == 'BSBL':
+        model_name = 'BSBL_PhotAstrom_Par_Param2'
+
+        # There should only be a single source companion.
+        comp_idxs_S = np.where(companions['prim_type'] == b"S")[0]
+        comp_idxs_L = np.where(companions['prim_type'] == b"L")[0]
+
+        if len(comp_idxs_S) > 1:
+            raise RuntimeError('Found too many source companions. Triples not supported.')
+        else:
+            comp_idx_S = comp_idxs_S[0]
+
+        if len(comp_idxs_L) > 1:
+            raise RuntimeError('Found too many lens companions. Triples not supported.')
+        else:
+            comp_idx_L = comp_idxs_L[0]
+
+        f_i = synthetic.filt_dict[photometric_system + '_' + filter_name][red_law]
+        abs_mag_sec = companions['m_%s_%s' % (photometric_system, filter_name)][comp_idx_S]
+
+        mLp = event['mass_L']  # msun (Lens current mass)
+        mLs = companions['mass'][comp_idx_L]  # msun (Companion lens current mass)
+        t0_p = event['t0']  # mjd
+        beta_p = event['u0'] * event['theta_E']  # 5.0
+        dL = event['rad_L'] * 10 ** 3  # Distance to lens
+        dS = event['rad_S'] * 10 ** 3  # Distance to source
+        xS0_E = 0.0  # arbitrary offset (arcsec)
+        xS0_N = 0.0  # arbitrary offset (arcsec)
+        sepL = companions['sep'][comp_idx_L]  # mas (separation between primary and companion)
+        alphaL = companions['alpha'][comp_idx_L]  # PA of binary on the sky
+        sepS = companions['sep'][comp_idx_S]  # mas (separation between primary and companion)
+        alphaS = companions['alpha'][comp_idx_S]  # PA of source binary on the sky
+        mag_src_sec = [synthetic.calc_app_mag(event['rad_S'], abs_mag_sec, event['exbv_S'], f_i)]
+        mag_src_pri = [binary_utils.subtract_magnitudes(
+            event['%s_%s_app_S' % (photometric_system, filter_name)], mag_src_sec)]
+        b_sff = [event['f_blend_%s' % filter_name]]  # ASSUMES THAT SOURCE BINARIES ARE BLENDED
+
+        parameter_dict = {'raL': raL, 'decL': decL, 'mLp': mLp, 'mLs': mLs,
+                          't0_p': t0_p, 'xS0_E': xS0_E, 'xS0_N': xS0_N, 'beta_p': beta_p,
+                          'muL_E': muL[0], 'muL_N': muL[1], 'muS_E': muS[0], 'muS_N': muS[1],
+                          'dL': dL, 'dS': dS, 'sepL': sepL, 'alphaL': alphaL,
+                          'sepS': sepS, 'alphaS': alphaS,
+                          'mag_src_pri': mag_src_pri, 'mag_src_sec': mag_src_sec,
+                          'b_sff': b_sff}
+
+    return model_name, parameter_dict

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4548,7 +4548,7 @@ def calc_blend_and_centroid(filter_name, red_law, blend_tab, photometric_system=
 
     # Convert absolute magnitudes to fluxes, and fix bad values
     flux_N = 10 ** (app_N / -2.5)
-    if type(flux_N) == MaskedColumn:
+    if type(flux_N) == np.ma.core.MaskedArray or type(flux_N) == MaskedColumn:
         flux_N = np.nan_to_num(flux_N.filled(np.nan))
     else:
         flux_N = np.nan_to_num(flux_N)
@@ -4599,13 +4599,13 @@ def _calc_observables(filter_name, red_law, event_tab, blend_tab, photometric_sy
     # Convert absolute magnitude to fluxes, and fix bad values
     flux_L = 10 ** (app_L / -2.5)
     flux_S = 10 ** (app_S / -2.5)
-
-    if type(flux_L) == MaskedColumn:
+    
+    if type(flux_L) == np.ma.core.MaskedArray or type(flux_L) == MaskedColumn:
         flux_L = np.nan_to_num(flux_L.filled(np.nan))
     else:
         flux_L = np.nan_to_num(flux_L)
 
-    if type(flux_S) == MaskedColumn:
+    if type(flux_S) == np.ma.core.MaskedArray or type(flux_S) == MaskedColumn:
         flux_S = np.nan_to_num(flux_S.filled(np.nan))
     else:
         flux_S = np.nan_to_num(flux_S)
@@ -5173,8 +5173,12 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
 
     comp_table['companion_idx'] = np.arange(len(comp_table))
 
+    comp_table.rename_column('m_ukirt_H', 'm_ubv_H')
+    comp_table.rename_column('m_ukirt_J', 'm_ubv_J')
+    comp_table.rename_column('m_ukirt_K', 'm_ubv_K')
+
     event_table['f_blend_%s' % filter_name] = event_table['f_blend_%s' % filter_name] # None of these should be nan
-    if type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == MaskedColumn:
+    if type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == np.ma.core.MaskedArray or type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == MaskedColumn:
         comp_table['m_%s_%s' % (photometric_system, filter_name)] = comp_table['m_%s_%s' % (photometric_system, filter_name)].filled(np.nan)
     
     event_table.add_column( Column(np.zeros(len(event_table), dtype=float), name='n_peaks') )

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -31,7 +31,7 @@ import subprocess
 import os
 from sklearn import neighbors
 import itertools
-from multiprocessing import Pool, Value, Lock, Manager
+from multiprocessing import Pool, Value, Lock
 import inspect
 import numpy.lib.recfunctions as rfn
 import copy
@@ -4548,11 +4548,8 @@ def calc_blend_and_centroid(filter_name, red_law, blend_tab, photometric_system=
 
     # Convert absolute magnitudes to fluxes, and fix bad values
     flux_N = 10 ** (app_N / -2.5)
-    if type(flux_N) == np.ma.core.MaskedArray or type(flux_N) == MaskedColumn:
-        flux_N = np.nan_to_num(flux_N.filled(np.nan))
-    else:
-        flux_N = np.nan_to_num(flux_N)
-        
+    flux_N = utils.nan_to_zero(flux_N)
+
     # Get total flux
     flux_N_tot = np.sum(flux_N)
 
@@ -4599,16 +4596,10 @@ def _calc_observables(filter_name, red_law, event_tab, blend_tab, photometric_sy
     # Convert absolute magnitude to fluxes, and fix bad values
     flux_L = 10 ** (app_L / -2.5)
     flux_S = 10 ** (app_S / -2.5)
-    
-    if type(flux_L) == np.ma.core.MaskedArray or type(flux_L) == MaskedColumn:
-        flux_L = np.nan_to_num(flux_L.filled(np.nan))
-    else:
-        flux_L = np.nan_to_num(flux_L)
 
-    if type(flux_S) == np.ma.core.MaskedArray or type(flux_S) == MaskedColumn:
-        flux_S = np.nan_to_num(flux_S.filled(np.nan))
-    else:
-        flux_S = np.nan_to_num(flux_S)
+    flux_L = utils.nan_to_zero(flux_L)
+
+    flux_S = utils.nan_to_zero(flux_S)
 
     ##########
     # Find the blends.

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4080,7 +4080,8 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
     Parameters
     ----------
     input_root : str
-        The root path and name of the \*_events.fits and \*_blends.fits.
+        The root path and name of the \*_events.fits, \*_blends.fits,
+        \*_galaxia_params.txt, \*_calc_events.log, and \_*_perform_pop_syn.log.
         Don't include those suffixes yet.
 
     filter_name : str

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -5870,7 +5870,11 @@ def get_bspl_lightcurve_parameters(event_table, comp_table, comp_idx, photometri
                             pm_l_cosb = event_table[event_id]['mu_lcosb_S']*unit.mas/unit.year, 
                               pm_b = event_table[event_id]['mu_b_S']*unit.mas/unit.year, frame ='galactic')
     f_i = filt_dict[photometric_system + '_' + filter_name][red_law]
-    abs_mag_sec = comp_table['m_%s_%s' % (photometric_system, filter_name)][comp_idx]
+    abs_mag_sec_col = comp_table['m_%s_%s' % (photometric_system, filter_name)]
+    if type(abs_mag_sec_col) == np.ma.core.MaskedArray or type(abs_mag_sec_col) == MaskedColumn:
+        abs_mag_sec_col = abs_mag_sec_col.filled(np.nan)
+        
+    abs_mag_sec = abs_mag_sec_col[comp_idx]
     
     raL = L_coords.icrs.ra.value # Lens R.A.
     decL = L_coords.icrs.dec.value # Lens dec
@@ -6001,7 +6005,11 @@ def get_bsbl_lightcurve_parameters(event_table, comp_table, comp_idx_L, comp_idx
                               pm_b = event_table[event_id]['mu_b_S']*unit.mas/unit.year, frame ='galactic')
 
     f_i = filt_dict[photometric_system + '_' + filter_name][red_law]
-    abs_mag_sec = comp_table['m_%s_%s' % (photometric_system, filter_name)][comp_idx_S]
+    abs_mag_sec_col = comp_table['m_%s_%s' % (photometric_system, filter_name)]
+    if type(abs_mag_sec_col) == np.ma.core.MaskedArray or type(abs_mag_sec_col) == MaskedColumn:
+        abs_mag_sec_col = abs_mag_sec_col.filled(np.nan)
+        
+    abs_mag_sec = abs_mag_sec_col[comp_idx_S]
 
     raL = L_coords.icrs.ra.value # Lens R.A.
     decL = L_coords.icrs.dec.value # Lens dec

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -5191,7 +5191,7 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
     
     lightcurve_table = Table(names=('obj_id_L', 'obj_id_S', 'companion_id_L', 'companion_id_S', 'class', 'n_peaks', 'bin_delta_m', 
                                      'tE_sys', 'tE_primary', 'primary_t', 'avg_t', 'std_t', 'asymmetry', 'mp_rows', 'used_lightcurve'),
-                            dtype = (float, float, float, float, str, float, float, float, float, float, float, float, float, dict, bool))
+                            dtype = (int, int, float, float, str, float, float, float, float, float, float, float, float, dict, bool))
     
     # This table is for events with more than one peak to characterize those peaks
     # comp_id is position of companion in companion table for reference
@@ -5201,7 +5201,7 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
     # delta m is the change in magnitude between the peak and baseline
     # ratio is the magnitude ratio between min peak/max peak
     mult_peaks = Table(names=('companion_idx', 'obj_id_L', 'obj_id_S', 'n_peaks', 't', 'tE', 'delta_m', 'ratio'),
-                       dtype = (object, float, float, float, float, float, float, float))
+                       dtype = (object, int, int, float, float, float, float, float))
     
     multiples_lightcurves = sum((event_table['isMultiple_S'] == 1) | (event_table['isMultiple_L'] == 1))
     
@@ -5223,8 +5223,6 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
         event_table_df['companion_idx_list'].loc[obj_id_L_S] = list(grouped_comps.groups[i]['companion_idx'])
         inputs[i] = [[event_table_df.loc[obj_id_L_S]], grouped_comps.groups[i].to_pandas(), obj_id_L, obj_id_S, 
                      photometric_system, filter_name, red_law, save_phot, phot_dir, overwrite]
-    
-    one_lightcurve_analysis
     
     if multi_proc:
         results = pool.starmap(one_lightcurve_analysis, inputs)
@@ -5456,10 +5454,10 @@ def one_lightcurve_analysis(event_table_row, comp_table_rows, obj_id_L, obj_id_S
             model_parameter_dict, _, _ = get_bspl_lightcurve_parameters(event_table_row, comp_table_rows, comp_idx, photometric_system, filter_name, red_law, event_id = 0)
             model = bspl_model_gen(model_parameter_dict)
             param_dict = lightcurve_parameter_gen(model, model_parameter_dict, np.array([global_comp_idx]), obj_id_L, obj_id_S, name, save_phot, phot_dir, overwrite)
-            lightcurve_dict = {'obj_id_L' : obj_id_L, 'obj_id_S' : obj_id_S, 'companion_id_L' : np.nan, 
+            lightcurve_dict = {'obj_id_L' : obj_id_L, 'obj_id_S' : obj_id_S, 'companion_id_L' : np.nan,
                                    'companion_id_S' : comp_table_rows['companion_idx'][comp_idx], 'class' : event_type}
             lightcurve_parameters.append([param_dict, lightcurve_dict])
-            
+
             del global_comp_idx, param_dict,
             lightcurve_dict, model, model_parameter_dict, name
 

--- a/popsycle/tests/test_analysis.py
+++ b/popsycle/tests/test_analysis.py
@@ -1,0 +1,36 @@
+import pytest
+import os
+from popsycle import analysis
+
+def test_get_star_system_pos_mag():
+    test_filepath = os.path.dirname(__file__)
+    in_root = 'data_test/test_correct_Mrun'
+
+    full_in_root = test_filepath + '/' + in_root
+
+    h5_file = full_in_root + '.h5'
+
+    df = analysis.get_star_system_pos_mag(h5_file)
+
+    assert 'm_ubv_I_app' in df.columns
+    assert 'glat' in df.columns
+    assert 'x' not in df.columns
+
+    return
+
+def test_count_stars_hdf5():
+    test_filepath = os.path.dirname(__file__)
+    in_root = 'data_test/test_correct_Mrun'
+
+    full_in_root = test_filepath + '/' + in_root
+
+    h5_file = full_in_root + '.h5'
+
+    N_stars = analysis.count_stars_hdf5(h5_file, mag_threshold=100)
+    assert N_stars == 37327
+
+    N_stars = analysis.count_stars_hdf5(h5_file, mag_threshold=21)
+    assert N_stars == 890
+
+    return
+

--- a/popsycle/tests/test_analysis.py
+++ b/popsycle/tests/test_analysis.py
@@ -10,7 +10,7 @@ def test_get_star_system_pos_mag():
 
     h5_file = full_in_root + '.h5'
 
-    df = analysis.get_star_system_pos_mag(h5_file)
+    df = analysis.get_star_system_pos_mag(h5_file, recalc=True)
 
     assert 'm_ubv_I_app' in df.columns
     assert 'glat' in df.columns

--- a/popsycle/tests/test_lightcurves.py
+++ b/popsycle/tests/test_lightcurves.py
@@ -1,0 +1,34 @@
+import pytest
+import os
+from popsycle import lightcurves
+from astropy.table import Table
+from bagle import model
+
+
+def test_get_bagle_model_list():
+    test_filepath = os.path.dirname(__file__)
+
+    # Specify photometric system variables.
+    photom_sys = 'ubv'
+    filter_name = 'I'
+    red_law = 'Damineli16'
+    n_multi_proc = 6
+
+    in_root = f'data_test/test_Mrun_refined_events_{photom_sys}_{filter_name}_{red_law}'
+
+    full_in_root = test_filepath + '/' + in_root
+
+    events_tab = Table.read(full_in_root + '_rb.fits')
+    comps_tab = Table.read(full_in_root + '_companions_rb.fits')
+    lcurves_tab = Table.read(full_in_root + '_rb_lightcurves.fits')
+
+    model_list = lightcurves.get_bagle_model_list(events_tab, comps_tab, lcurves_tab,
+                                                  photom_sys, filter_name, red_law,
+                                                  n_multi_proc=n_multi_proc)
+
+    assert isinstance(model_list[0], model.PSBL_PhotAstrom_Par_Param7)
+    assert len(model_list) == len(events_tab)
+
+    return
+
+

--- a/popsycle/utils.py
+++ b/popsycle/utils.py
@@ -689,3 +689,26 @@ def remove_nan_companions(event_table_loc, comp_table_loc, event_output_loc = No
                         empty_line, line8, dash_line, line9, line10])
     
     return
+
+
+def nan_to_zero(flux):
+    """
+    Modify the input flux array (or any numpy array for that matter) to replace all
+    nan values with zeros.
+
+    Parameters
+    ----------
+    flux : numpy array or Column
+        Array of flux values. Can be me a regular numpy array or a Masked array or column.
+
+    Returns
+    -------
+    flux : numpy array or Column
+        copy of array now with nan's replaced with zeros
+    """
+    if type(flux) == np.ma.core.MaskedArray or type(flux) == MaskedColumn:
+        flux = np.nan_to_num(flux.filled(np.nan))
+    else:
+        flux = np.nan_to_num(flux)
+
+    return flux


### PR DESCRIPTION
This PR includes the following

- Functions to manipulate lightcurves
    - Generate BAGLE models and parameters given a table of events
- HDF5 analysis utilities
    - Return a table with lists of star systems and their RA, Dec, z position, and system apparent magnitude. This is useful for making stellar density maps, computing microlens event occurrence rates, etc.
    - Count number of stars in hdf5 file
    - Makes a fraction of black holes single after perform_pop_syn. This is a temporary fix since there is no binary evolution and all the black holes end up in binaries.
- Bug Fixes
    - Issues involving masked columns causing masked blends and magnitudes instead of nans or correctly added ones
    - Column names of magnitudes of companion table