### PR TITLE
Multiband refine events

### DIFF
--- a/docs/PopSyCLE_example.ipynb
+++ b/docs/PopSyCLE_example.ipynb
@@ -419,7 +419,7 @@
    "source": [
     "# Photometry\n",
     "\n",
-    "This is the last thing, where you choose the photometric band for the observations and the reddening law.\n",
+    "This is the last thing, where you choose the photometric band or bands for the observations and the reddening law.\n",
     "The final file of microlensing events is produced here as a .fits file."
    ]
   },
@@ -442,8 +442,7 @@
    ],
    "source": [
     "synthetic.refine_events(input_root = 'example', \n",
-    "                        filter_name = 'I',\n",
-    "                        photometric_system = 'ubv',\n",
+    "                        filter_dict={'ubv':['I']},\n",
     "                        red_law = 'Damineli16', \n",
     "                        overwrite = False, \n",
     "                        output_file = 'default')"

--- a/docs/PopSyCLE_example_multiples.ipynb
+++ b/docs/PopSyCLE_example_multiples.ipynb
@@ -831,7 +831,7 @@
    "source": [
     "# Photometry\n",
     "\n",
-    "In refine_events you specify a photometric band for the observations and the reddening law.\n",
+    "In refine_events you specify a photometric band or bands for the observations and the reddening law.\n",
     "The final file of microlensing events is produced here as a .fits file.\n",
     "To include multiples you must specify the hdf5 companion file."
    ]
@@ -860,8 +860,7 @@
    "source": [
     "synthetic.refine_events(input_root = 'example',\n",
     "                        hdf5_file_comp = 'example_companions.h5',\n",
-    "                        filter_name = 'I',\n",
-    "                        photometric_system = 'ubv',\n",
+    "                        filter_dict={'ubv':['I']},\n",
     "                        red_law = 'Damineli16', \n",
     "                        overwrite = False, \n",
     "                        output_file = 'default')"

--- a/docs/PopSyCLE_example_run.ipynb
+++ b/docs/PopSyCLE_example_run.ipynb
@@ -43,8 +43,7 @@
     "                                  bin_edges_number=None,\n",
     "                                  BH_kick_speed_mean=50,\n",
     "                                  NS_kick_speed_mean=400,\n",
-    "                                  photometric_system='ubv',\n",
-    "                                  filter_name='R',\n",
+    "                                  filter_dict={'ubv':['R']},\n",
     "                                  red_law='Damineli16',\n",
     "                                  multiplicity=None,\n",
     "                                  galaxia_galaxy_model_filename= '/g/lu/code/galaxia/docs/galaxyModelParams_PopSyCLEv3.txt')"

--- a/docs/PopSyCLE_example_slurm.ipynb
+++ b/docs/PopSyCLE_example_slurm.ipynb
@@ -78,8 +78,7 @@
     "                                  bin_edges_number=None,\n",
     "                                  BH_kick_speed_mean=50,\n",
     "                                  NS_kick_speed_mean=400,\n",
-    "                                  photometric_system='ubv',\n",
-    "                                  filter_name='r',\n",
+    "                                  filter_dict={'ubv':['R']},\n",
     "                                  red_law='Damineli16',\n",
     "                                  multiplicity=None)"
    ]

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -1181,7 +1181,7 @@ def run(output_root='root0',
 
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
-        synthetic.refine_binary_events(events=refined_events_filename, # CHANGE HERE
+        synthetic.refine_binary_events(events=refined_events_filename,
                                        companions=refined_events_comp_filename,
                                        filter_name=filter_name,
                                        photometric_system=photometric_system,

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -253,12 +253,14 @@ def generate_popsycle_config_file(radius_cut=2, obs_time=1000,
 
     filter_dict : dict
         Dictionary with desired photometric systems and filters to calculate microlensing events for.
-        The dictionary keys are photometric systems.
+        The dictionary keys are strings of photometric systems.
         The dictionary values are lists of strings filled with filters within that photometric system key.
         Example:
             To calculate the events for UBV U, and ZTF, u, g, r: 
                 filter_dict = {'ubv':['U'],'ztf':['u','g','r']}
         NOTE: photometric_system and filter_name are deprecated, please use filter_dict.
+        NOTE: When running refine_binary_events, the first dictionary key and value are used.
+              The above example would use UBV U in refine_binary_events.
 
     red_law : str
         The name of the reddening law to use from SPISEA.

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -674,14 +674,23 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
                              hdf5_file_comp=hdf5_file_comp,
                              seed=seed)
     if not skip_refine_binary_events:
-        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
-        filt_name = popsycle_config['filter_dict'][photometric_system][0]
+        # refined_events_filename defaults to using multi_filt, 
+        # unless popsycle_config['filter_dict'] contains only one filter
         refined_events_filename = '{0:s}_refined_events_' \
-                              '{1:s}_{2:s}_{3:s}.' \
+                              'multi_filt_{1:s}.' \
                               'fits'.format(output_root,
-                                            photometric_system,
-                                            filt_name,
                                             popsycle_config['red_law'])
+        if len(popsycle_config['filter_dict'])==1:
+            list_ = list(popsycle_config['filter_dict'].keys())[0]
+            if len(popsycle_config['filter_dict'][list_]) == 1:
+                photometric_system = popsycle_config['filter_dict'].keys[0]
+                filter_name = popsycle_config['filter_dict'][photometric_system]
+                refined_events_filename = '{0:s}_refined_events_' \
+                                          '{1:s}_{2:s}_{3:s}.' \
+                                          'fits'.format(output_root,
+                                                        photometric_system,
+                                                        filter_name,
+                                                        popsycle_config['red_law'])
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
         _check_refine_binary_events(events=refined_events_filename,
@@ -1061,15 +1070,26 @@ def run(output_root='root0',
                              hdf5_file_comp=hdf5_file_comp,
                              seed=seed)
     if not skip_refine_binary_events:
-        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
-        filter_name = popsycle_config['filter_dict'][photometric_system][0]        
+        # refined_events_filename defaults to using multi_filt, 
+        # unless popsycle_config['filter_dict'] contains only one filter
         refined_events_filename = '{0:s}_refined_events_' \
-                              '{1:s}_{2:s}_{3:s}.' \
+                              'multi_filt_{1:s}.' \
                               'fits'.format(output_root,
-                                            photometric_system,
-                                            filter_name,
                                             popsycle_config['red_law'])
+        if len(popsycle_config['filter_dict'])==1:
+            list_ = list(popsycle_config['filter_dict'].keys())[0]
+            if len(popsycle_config['filter_dict'][list_]) == 1:
+                photometric_system = popsycle_config['filter_dict'].keys[0]
+                filter_name = popsycle_config['filter_dict'][photometric_system]
+                refined_events_filename = '{0:s}_refined_events_' \
+                                          '{1:s}_{2:s}_{3:s}.' \
+                                          'fits'.format(output_root,
+                                                        photometric_system,
+                                                        filter_name,
+                                                        popsycle_config['red_law'])
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
+        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
+        filter_name = popsycle_config['filter_dict'][photometric_system][0]
         phot_dir = '%s_bin_phot' % output_root
         _check_refine_binary_events(events=refined_events_filename,
                                     companions=refined_events_comp_filename,
@@ -1155,12 +1175,25 @@ def run(output_root='root0',
             t1 = time.time()
             print('run.py runtime : {0:f} s'.format(t1 - t0))
             sys.exit(0)
-    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in popsycle_config['filter_dict'].items()])
+            
+    # refined_events_filename defaults to using multi_filt, 
+    # unless popsycle_config['filter_dict'] contains only one filter
     refined_events_filename = '{0:s}_refined_events_' \
-                              '{1:s}_{2:s}.' \
-                              'fits'.format(output_root,
-                                            filters_string,
-                                            popsycle_config['red_law'])
+                          'multi_filt_{1:s}.' \
+                          'fits'.format(output_root,
+                                        popsycle_config['red_law'])
+    if len(popsycle_config['filter_dict'])==1:
+        list_ = list(popsycle_config['filter_dict'].keys())[0]
+        if len(popsycle_config['filter_dict'][list_]) == 1:
+            photometric_system = popsycle_config['filter_dict'].keys[0]
+            filter_name = popsycle_config['filter_dict'][photometric_system]
+            refined_events_filename = '{0:s}_refined_events_' \
+                                      '{1:s}_{2:s}_{3:s}.' \
+                                      'fits'.format(output_root,
+                                                    photometric_system,
+                                                    filter_name,
+                                                    popsycle_config['red_law'])
+
     if not skip_refine_events:
         # Remove refine_events output if already exists and overwrite=True
         if _check_for_output(refined_events_filename, overwrite):
@@ -1189,6 +1222,8 @@ def run(output_root='root0',
 
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
+        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
+        filter_name = popsycle_config['filter_dict'][photometric_system][0]
         synthetic.refine_binary_events(events=refined_events_filename,
                                        companions=refined_events_comp_filename,
                                        filter_name=filter_name,

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -618,6 +618,14 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
     n_cores_popsycle = {'n_cores_perform_pop_syn' : n_cores_perform_pop_syn,
                         'n_cores_calc_events' : n_cores_calc_events,
                         'n_cores_refine_binary_events' : n_cores_refine_binary_events}
+    
+    # Prepare additional_photometric_systems
+    additional_photometric_systems = []
+    for photometric_system in popsycle_config['filter_dict']:
+        if photometric_system != 'ubv':
+            additional_photometric_systems += [photometric_system]
+    if additional_photometric_systems == []:
+        additional_photometric_systems = None
 
     # Check pipeline stages for valid inputs
     _check_slurm_config(slurm_config, walltime)
@@ -638,7 +646,7 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
                                bin_edges_number=popsycle_config['bin_edges_number'],
                                BH_kick_speed_mean=popsycle_config['BH_kick_speed_mean'],
                                NS_kick_speed_mean=popsycle_config['NS_kick_speed_mean'],
-                               additional_photometric_systems=[popsycle_config['photometric_system']],
+                               additional_photometric_systems=additional_photometric_systems,
                                n_proc=n_cores_perform_pop_syn,
                                binning = popsycle_config['binning'],
                                verbose = verbose,

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -665,18 +665,18 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
                              seed=seed)
     if not skip_refine_binary_events:
         photometric_system = list(popsycle_config['filter_dict'].keys())[0]
-        filt = popsycle_config['filter_dict'][photometric_system][0]
+        filt_name = popsycle_config['filter_dict'][photometric_system][0]
         refined_events_filename = '{0:s}_refined_events_' \
                               '{1:s}_{2:s}_{3:s}.' \
                               'fits'.format(output_root,
                                             photometric_system,
-                                            filt,
+                                            filt_name,
                                             popsycle_config['red_law'])
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
         _check_refine_binary_events(events=refined_events_filename,
                                     companions=refined_events_comp_filename,
-                                    filter_name=filt,
+                                    filter_name=filt_name,
                                     photometric_system=photometric_system,
                                     n_proc=n_cores_refine_binary_events,
                                     overwrite=overwrite,

--- a/popsycle/run.py
+++ b/popsycle/run.py
@@ -194,8 +194,8 @@ def generate_popsycle_config_file(radius_cut=2, obs_time=1000,
                                   bin_edges_number=None,
                                   BH_kick_speed_mean=50,
                                   NS_kick_speed_mean=400,
-                                  photometric_system='ubv',
-                                  filter_name='R', red_law='Damineli16',
+                                  filter_dict={'ubv':['R']},
+                                  red_law='Damineli16',
                                   multiplicity=None,
                                   binning = True,
                                   config_filename='popsycle_config.yaml'):
@@ -251,13 +251,14 @@ def generate_popsycle_config_file(radius_cut=2, obs_time=1000,
         Hobbs et al 2005 'A statistical study of 233 pulsar proper motions'.
         https://ui.adsabs.harvard.edu/abs/2005MNRAS.360..974H/abstract
 
-    photometric_system : str
-        The name of the photometric system in which the filter exists.
-
-    filter_name : str
-        The name of the filter in which to calculate all the
-        microlensing events. The filter name convention is set
-        in the global filt_dict parameter at the top of this module.
+    filter_dict : dict
+        Dictionary with desired photometric systems and filters to calculate microlensing events for.
+        The dictionary keys are photometric systems.
+        The dictionary values are lists of strings filled with filters within that photometric system key.
+        Example:
+            To calculate the events for UBV U, and ZTF, u, g, r: 
+                filter_dict = {'ubv':['U'],'ztf':['u','g','r']}
+        NOTE: photometric_system and filter_name are deprecated, please use filter_dict.
 
     red_law : str
         The name of the reddening law to use from SPISEA.
@@ -302,8 +303,7 @@ def generate_popsycle_config_file(radius_cut=2, obs_time=1000,
               'bin_edges_number': bin_edges_number,
               'BH_kick_speed_mean': BH_kick_speed_mean,
               'NS_kick_speed_mean': NS_kick_speed_mean,
-              'photometric_system': photometric_system,
-              'filter_name': filter_name,
+              'filter_dict': filter_dict,
               'red_law': red_law,
               'multiplicity': multiplicity,
               'binning':binning}
@@ -656,8 +656,7 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
                            hdf5_file_comp=hdf5_file_comp)
     if not skip_refine_events:
         _check_refine_events(input_root='test',
-                             filter_name=popsycle_config['filter_name'],
-                             photometric_system=popsycle_config['photometric_system'],
+                             filter_dict=popsycle_config['filter_dict'],
                              red_law=popsycle_config['red_law'],
                              overwrite=overwrite,
                              legacy=False,
@@ -665,18 +664,20 @@ def generate_slurm_script(slurm_config_filename, popsycle_config_filename,
                              hdf5_file_comp=hdf5_file_comp,
                              seed=seed)
     if not skip_refine_binary_events:
+        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
+        filt = popsycle_config['filter_dict'][photometric_system][0]
         refined_events_filename = '{0:s}_refined_events_' \
                               '{1:s}_{2:s}_{3:s}.' \
                               'fits'.format(output_root,
-                                            popsycle_config['photometric_system'],
-                                            popsycle_config['filter_name'],
+                                            photometric_system,
+                                            filt,
                                             popsycle_config['red_law'])
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
         _check_refine_binary_events(events=refined_events_filename,
                                     companions=refined_events_comp_filename,
-                                    photometric_system=popsycle_config['photometric_system'],
-                                    filter_name=popsycle_config['filter_name'],
+                                    filter_name=filt,
+                                    photometric_system=photometric_system,
                                     n_proc=n_cores_refine_binary_events,
                                     overwrite=overwrite,
                                     output_file='default', save_phot=True,
@@ -977,19 +978,23 @@ def run(output_root='root0',
     popsycle_config = load_config_file(popsycle_config_filename)
     if popsycle_config['bin_edges_number'] == 'None':
         popsycle_config['bin_edges_number'] = None
-    if popsycle_config['photometric_system'] not in synthetic.photometric_system_dict:
-        print("""Error: 'photometric_system' in {0} must be a valid option 
-        in 'photometric_system_dict'. 
-        Exiting...""".format(popsycle_config_filename))
-        sys.exit(1)
+    for photometric_system in popsycle_config['filter_dict']:
+        if photometric_system not in synthetic.photometric_system_dict:
+            print("""Error: photometric system: {0} in filter_dict in {1} must be a valid option 
+            in 'photometric_system_dict'. 
+            Exiting...""".format(photometric_system, popsycle_config_filename))
+            sys.exit(1)
 
     # Return the dictionary containing PopSyCLE output filenames
     filename_dict = _return_filename_dict(output_root)
 
     # Prepare additional_photometric_systems
-    additional_photometric_systems = None
-    if popsycle_config['photometric_system'] != 'ubv':
-        additional_photometric_systems = [popsycle_config['photometric_system']]
+    additional_photometric_systems = []
+    for photometric_system in popsycle_config['filter_dict']:
+        if photometric_system != 'ubv':
+            additional_photometric_systems += [photometric_system]
+    if additional_photometric_systems == []:
+        additional_photometric_systems = None
 
     # Load multiplicity from popsycle_config
     multiplicity = multiplicity_list[popsycle_config['multiplicity']]
@@ -1038,8 +1043,7 @@ def run(output_root='root0',
                            hdf5_file_comp=hdf5_file_comp)
     if not skip_refine_events:
         _check_refine_events(input_root=output_root,
-                             filter_name=popsycle_config['filter_name'],
-                             photometric_system=popsycle_config['photometric_system'],
+                             filter_dict=popsycle_config['filter_dict'],
                              red_law=popsycle_config['red_law'],
                              overwrite=overwrite,
                              legacy=False,
@@ -1047,18 +1051,20 @@ def run(output_root='root0',
                              hdf5_file_comp=hdf5_file_comp,
                              seed=seed)
     if not skip_refine_binary_events:
+        photometric_system = list(popsycle_config['filter_dict'].keys())[0]
+        filter_name = popsycle_config['filter_dict'][photometric_system][0]        
         refined_events_filename = '{0:s}_refined_events_' \
                               '{1:s}_{2:s}_{3:s}.' \
                               'fits'.format(output_root,
-                                            popsycle_config['photometric_system'],
-                                            popsycle_config['filter_name'],
+                                            photometric_system,
+                                            filter_name,
                                             popsycle_config['red_law'])
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
         _check_refine_binary_events(events=refined_events_filename,
                                     companions=refined_events_comp_filename,
-                                    photometric_system=popsycle_config['photometric_system'],
-                                    filter_name=popsycle_config['filter_name'],
+                                    filter_name=filter_name,
+                                    photometric_system=photometric_system,
                                     n_proc=n_cores_refine_binary_events,
                                     overwrite=overwrite,
                                     output_file='default', save_phot=True,
@@ -1139,12 +1145,11 @@ def run(output_root='root0',
             t1 = time.time()
             print('run.py runtime : {0:f} s'.format(t1 - t0))
             sys.exit(0)
-
+    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in popsycle_config['filter_dict'].items()])
     refined_events_filename = '{0:s}_refined_events_' \
-                              '{1:s}_{2:s}_{3:s}.' \
+                              '{1:s}_{2:s}.' \
                               'fits'.format(output_root,
-                                            popsycle_config['photometric_system'],
-                                            popsycle_config['filter_name'],
+                                            filters_string,
                                             popsycle_config['red_law'])
     if not skip_refine_events:
         # Remove refine_events output if already exists and overwrite=True
@@ -1156,8 +1161,7 @@ def run(output_root='root0',
         # Run refine_events
         print('-- Executing refine_events')
         synthetic.refine_events(input_root=output_root,
-                                filter_name=popsycle_config['filter_name'],
-                                photometric_system=popsycle_config['photometric_system'],
+                                filter_dict=popsycle_config['filter_dict'],
                                 red_law=popsycle_config['red_law'],
                                 overwrite=overwrite,
                                 output_file='default',
@@ -1175,10 +1179,10 @@ def run(output_root='root0',
 
         refined_events_comp_filename = refined_events_filename.replace('.fits', '_companions.fits')
         phot_dir = '%s_bin_phot' % output_root
-        synthetic.refine_binary_events(events=refined_events_filename,
+        synthetic.refine_binary_events(events=refined_events_filename, # CHANGE HERE
                                        companions=refined_events_comp_filename,
-                                       photometric_system=popsycle_config['photometric_system'],
-                                       filter_name=popsycle_config['filter_name'],
+                                       filter_name=filter_name,
+                                       photometric_system=photometric_system,
                                        n_proc=n_cores_refine_binary_events,
                                        overwrite=overwrite,
                                        output_file='default', save_phot=True,

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1310,6 +1310,7 @@ def _process_popsyn_stars_in_bin(bin_idx, age_of_bin, metallicity_of_bin,
                              co_dict, output_root)
             _bin_lb_hdf5(lat_bin_edges, long_bin_edges,
                          stars_in_bin, output_root)
+            
 
         else:
             if co_dict is not None:
@@ -4395,11 +4396,17 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
         warn('filter_name and photometric_system are deprecated, please use filter_dict', DeprecationWarning, stacklevel=2)
         filter_dict = {photometric_system:[filter_name]}
     
-    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filter_dict.items()])
     if output_file == 'default':
-        output_file = '{0:s}_refined_events_{1:s}_{2:s}.fits'.format(input_root, 
-                                                                     filters_string,
-                                                                     red_law)
+        system = list(filter_dict.keys())[0]
+        filt = filter_dict[system][0]
+        if len(filter_dict) == 1 and len(filter_dict[system]) == 1: 
+            output_file = '{0:s}_refined_events_{1:s}_{2:s}_{3:s}.fits'.format(input_root, 
+                                                                               system,
+                                                                               filt,
+                                                                               red_law)
+        else:
+            output_file = '{0:s}_refined_events_multi_filt_{1:s}.fits'.format(input_root, 
+                                                                              red_law)
 
     t_0 = time.time()
 
@@ -4526,6 +4533,12 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
         event_tab['gal_seed'] = np.ones(len(event_tab)) * gal_seed
 
         event_tab.write(output_file, overwrite=overwrite)
+        
+        # Add the filter_dict as a header to store metadata # CHANGE HERE
+        filters_string = ', '.join([': '.join([system, ', '.join(filts)]) for system , filts in filter_dict.items()])
+        with fits.open(output_file, mode='update') as hdul:
+            header = hdul[0].header
+            header['filter_dict'] = filters_string
     
     
 

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4178,10 +4178,8 @@ def _convert_photometric_99_to_nan(table, photometric_system='ubv'):
             table[name][cond] = np.nan
 
 
-def _check_refine_events(input_root, red_law, overwrite,
-                         output_file, hdf5_file_comp, legacy, seed,
-                         filter_name = None, photometric_system = None
-                         filter_dict = None):
+def _check_refine_events(input_root,filter_dict, red_law, overwrite,
+                         output_file, hdf5_file_comp, legacy, seed):
     """
     Checks that the inputs of refine_events are valid
 
@@ -4220,18 +4218,9 @@ def _check_refine_events(input_root, red_law, overwrite,
 
     if not isinstance(input_root, str):
         raise Exception('input_root (%s) must be a string.' % str(input_root))
- 
-    if filter_name is not None:
-        if not isinstance(filter_name, str):
-            raise Exception('filter_name (%s) must be a string or list.' % str(filter_name))
-
-    if photometric_system is not None:
-        if not isinstance(photometric_system, str):
-            raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))
     
-    if filter_dict is not None:
-        if not isinstance(filters_dict, dict):
-            raise Exception('filters_dict (%s) must be a dictionary.' % str(filters_dict))
+    if not isinstance(filters_dict, dict):
+        raise Exception('filters_dict (%s) must be a dictionary.' % str(filters_dict))
 
     if not isinstance(red_law, str):
         raise Exception('red_law (%s) must be a string.' % str(red_law))
@@ -4253,9 +4242,9 @@ def _check_refine_events(input_root, red_law, overwrite,
         if not isinstance(seed, int):
             raise Exception('seed (%s) must be None or an integer.' % str(seed))
 
-    # Check to see that the filter name, photometric system, filter dictionary, and/or red_law are valid
-    if photometric_system is not None:
-        if photometric_system not in photometric_system_dict:
+    # Check to see that the filter dictionary, and red_law are valid
+    for system in filters_dict:
+        if system not in photometric_system_dict:
             exception_str = 'photometric_system must be a key in ' \
                             'photometric_system_dict. \n' \
                             'Acceptable values are : '
@@ -4263,37 +4252,16 @@ def _check_refine_events(input_root, red_law, overwrite,
                 exception_str += '%s, ' % photometric_system
             exception_str = exception_str[:-2]
             raise Exception(exception_str)
-            
-    if filter_name is not None:
-        if filter_name not in photometric_system_dict[photometric_system]:
-            exception_str = 'filter_name must be a value in ' \
-                            'photometric_system_dict[%s]. \n' \
-                            'Acceptable values are : ' % photometric_system
-            for filter_name in photometric_system_dict[photometric_system]:
-                exception_str += '%s, ' % filter_name
-            exception_str = exception_str[:-2]
-            raise Exception(exception_str)
-            
-    if filter_dict is not None:
-        for system in filters_dict:
-            if system not in photometric_system_dict:
-                exception_str = 'photometric_system must be a key in ' \
-                                'photometric_system_dict. \n' \
-                                'Acceptable values are : '
-                for photometric_system in photometric_system_dict:
-                    exception_str += '%s, ' % photometric_system
+
+        for filt in filters_dict[system]:
+            if filt not in photometric_system_dict[system]:
+                exception_str = 'filter_name must be a value in ' \
+                                'photometric_system_dict[%s]. \n' \
+                                'Acceptable values are : ' % system
+                for filter_name in photometric_system_dict[system]:
+                    exception_str += '%s, ' % filter_name
                 exception_str = exception_str[:-2]
                 raise Exception(exception_str)
-
-            for filt in filters_dict[system]:
-                if filt not in photometric_system_dict[system]:
-                    exception_str = 'filter_name must be a value in ' \
-                                    'photometric_system_dict[%s]. \n' \
-                                    'Acceptable values are : ' % system
-                    for filter_name in photometric_system_dict[system]:
-                        exception_str += '%s, ' % filter_name
-                    exception_str = exception_str[:-2]
-                    raise Exception(exception_str)
             
     key = photometric_system + '_' + filter_name
     if red_law not in filt_dict[key]:
@@ -4306,7 +4274,7 @@ def _check_refine_events(input_root, red_law, overwrite,
         raise Exception(exception_str)
 
 
-def refine_events(input_root, filter_name, photometric_system, red_law,
+def refine_events(input_root, filter_dict, red_law,
                   overwrite=False,
                   output_file='default', hdf5_file_comp=None, legacy = False, seed = None):
     """
@@ -4377,15 +4345,14 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
                         'Either delete the .fits file, or pick a new name.')
 
     # Error handling/complaining if input types are not right.
-    _check_refine_events(input_root, filter_name,
-                         photometric_system, red_law,
+    _check_refine_events(input_root, filter_dict, red_law,
                          overwrite, output_file, hdf5_file_comp, legacy, seed)
-
+    
+    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filters_dict.items()])
     if output_file == 'default':
-        output_file = '{0:s}_refined_events_{1:s}_{2:s}_{3:s}.fits'.format(input_root,
-                                                                           photometric_system,
-                                                                           filter_name,
-                                                                           red_law)
+        output_file = '{0:s}_refined_events_{1:s}_{2:s}.fits'.format(input_root, 
+                                                                     output_filters_string,
+                                                                     red_law)
 
     t_0 = time.time()
 
@@ -4402,7 +4369,7 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
                      perform_pop_syn_log_file]:
         if not os.path.exists(filename):
             raise Exception(f'{filename} cannot be found.')
-
+    
     event_tab = Table.read(event_fits_file)
     blend_tab = Table.read(blend_fits_file)
     
@@ -4417,11 +4384,16 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
         
 
     # If photometric fields contain -99, convert to nan
-    _convert_photometric_99_to_nan(event_tab, photometric_system)
-    _convert_photometric_99_to_nan(blend_tab, photometric_system)
+    photometric_system = filters_dict.keys()
+    filter_name = filters_dict.values()
+    for system in photometric_system:
+        _convert_photometric_99_to_nan(event_tab, photometric_system)
+        _convert_photometric_99_to_nan(blend_tab, photometric_system)
 
     # Only keep events with luminous sources
-    event_tab = event_tab[~np.isnan(event_tab[photometric_system + '_' + filter_name + '_S'])]
+    for system in filters_dict:
+        for filters in filters_dict[system]:
+            event_tab = event_tab[~np.isnan(event_tab[system + '_' + filters + '_S'])]
 
     # Grab the obs_time from the calc_events log
     with open(calc_events_log_file, 'r') as my_file:
@@ -4490,7 +4462,9 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
         event_tab['t_E'] = t_E  # days
 
         # Add stuff to event_tab... shouldn't have any direct outputs
-        _calc_observables(filter_name, red_law, event_tab, blend_tab, photometric_system)
+        for system in filter_dict:
+            for filters in filter_dict[system]:
+                _calc_observables(filters, red_law, event_tab, blend_tab, system)
 
         # Relative parallax
         pi_rel = event_tab['rad_L'] ** -1 - event_tab['rad_S'] ** -1
@@ -4628,7 +4602,7 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
 
     line0 = 'FUNCTION INPUT PARAMETERS' + '\n'
     line1 = 'input_root : ' + input_root + '\n'
-    line2 = 'filter_name : ' + filter_name + '\n'
+    line2 = 'filter_dict : ' + ', '.join([': '.join([system, ', '.join(filts)]) for system , filts in filters_dict.items()]) + '\n'
     line3 = 'red_law : ' + red_law + '\n'
 
     line4 = 'VERSION INFORMATION' + '\n'
@@ -4648,12 +4622,14 @@ def refine_events(input_root, filter_name, photometric_system, red_law,
     if hdf5_file_comp is not None:
         if len(companion_table) > 0:
             line14 = output_file[:-5] + "_companions.fits" + ' : companions refined events'
-
-    with open(input_root + '_refined_events_' + photometric_system + '_' + filter_name + '_' + red_law + '.log', 'w') as out:
-        out.writelines([line0, dash_line, line1, line2, line3, empty_line,
-                        line4, dash_line, line5, line6, line7, empty_line,
-                        line8, dash_line, line9, line10, line11, empty_line,
-                        line12, dash_line, line13, line14])
+    
+    for system in filter_dict:
+        for filters in filter_dict[system]:
+            with open(input_root + '_refined_events_' + system + '_' + filters + '_' + red_law + '.log', 'w') as out:
+                out.writelines([line0, dash_line, line1, line2, line3, empty_line,
+                                line4, dash_line, line5, line6, line7, empty_line,
+                                line8, dash_line, line9, line10, line11, empty_line,
+                                line12, dash_line, line13, line14])
 
     print('refine_events runtime : {0:f} s'.format(t_1 - t_0))
     return

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4178,7 +4178,7 @@ def _convert_photometric_99_to_nan(table, photometric_system='ubv'):
             table[name][cond] = np.nan
 
 
-def _check_refine_events(input_root,filter_dict, red_law, overwrite, output_file, 
+def _check_refine_events(input_root, filter_dict, red_law, overwrite, output_file, 
                          hdf5_file_comp, legacy, seed, filter_name=None, photometric_system=None):
     """
     Checks that the inputs of refine_events are valid

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -1864,13 +1864,13 @@ def _make_co_dict(log_age,
                         co_dict['sdss_r'][lum_co_sys_idx] = co_table['m_sdss_r'][lum_co_sys_idx].data
                         co_dict['sdss_i'][lum_co_sys_idx] = co_table['m_sdss_i'][lum_co_sys_idx].data
                         co_dict['sdss_z'][lum_co_sys_idx] = co_table['m_sdss_z'][lum_co_sys_idx].data
-                        co_dict['sdss_y'][lum_co_sys_idx] = co_table['m_sdss_y'][lum_co_sys_idx].data
                     if 'rubin' in additional_photometric_systems:
                         co_dict['rubin_u'][lum_co_sys_idx] = co_table['m_rubin_u'][lum_co_sys_idx].data
                         co_dict['rubin_g'][lum_co_sys_idx] = co_table['m_rubin_g'][lum_co_sys_idx].data
                         co_dict['rubin_r'][lum_co_sys_idx] = co_table['m_rubin_r'][lum_co_sys_idx].data
                         co_dict['rubin_i'][lum_co_sys_idx] = co_table['m_rubin_i'][lum_co_sys_idx].data
                         co_dict['rubin_z'][lum_co_sys_idx] = co_table['m_rubin_z'][lum_co_sys_idx].data
+                        co_dict['rubin_y'][lum_co_sys_idx] = co_table['m_rubin_y'][lum_co_sys_idx].data
                     if 'roman' in additional_photometric_systems:
                         co_dict['roman_f062'][lum_co_sys_idx] = co_table['m_roman_f062'][lum_co_sys_idx].data
                         co_dict['roman_f087'][lum_co_sys_idx] = co_table['m_roman_f087'][lum_co_sys_idx].data
@@ -3087,7 +3087,7 @@ def _make_companions_table(cluster, star_dict, co_dict,
                     companions_system_m_rubin_r = grouped_companions['m_rubin_r'].groups.aggregate(binary_utils.add_magnitudes)
                     companions_system_m_rubin_i = grouped_companions['m_rubin_i'].groups.aggregate(binary_utils.add_magnitudes)
                     companions_system_m_rubin_z = grouped_companions['m_rubin_z'].groups.aggregate(binary_utils.add_magnitudes)
-                    companions_system_m_rubin_z = grouped_companions['m_rubin_y'].groups.aggregate(binary_utils.add_magnitudes)
+                    companions_system_m_rubin_y = grouped_companions['m_rubin_y'].groups.aggregate(binary_utils.add_magnitudes)
                 if 'roman' in additional_photometric_systems:
                     companions_system_m_roman_f062 = grouped_companions['m_roman_f062'].groups.aggregate(binary_utils.add_magnitudes)
                     companions_system_m_roman_f087 = grouped_companions['m_roman_f087'].groups.aggregate(binary_utils.add_magnitudes)
@@ -4178,7 +4178,7 @@ def _convert_photometric_99_to_nan(table, photometric_system='ubv'):
             table[name][cond] = np.nan
 
 
-def _check_refine_events(input_root,filter_dict, red_law, overwrite,
+def _check_refine_events(input_root,filter_dict, filter_name, photometric_system, red_law, overwrite,
                          output_file, hdf5_file_comp, legacy, seed):
     """
     Checks that the inputs of refine_events are valid
@@ -4219,8 +4219,17 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
     if not isinstance(input_root, str):
         raise Exception('input_root (%s) must be a string.' % str(input_root))
     
-    if not isinstance(filter_dict, dict):
-        raise Exception('filter_dict (%s) must be a dictionary.' % str(filter_dict))
+    if filter_dict is not None:
+        if not isinstance(filter_dict, dict):
+            raise Exception('filter_dict (%s) must be a dictionary.' % str(filter_dict))
+        
+    if filter_name is not None:
+        if not isinstance(filter_name, str):
+            raise Exception('filter_name (%s) must be a string.' % str(filter_name))        
+
+    if photometric_system is not None:
+        if not isinstance(photometric_system, str):
+            raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))   
 
     if not isinstance(red_law, str):
         raise Exception('red_law (%s) must be a string.' % str(red_law))
@@ -4241,8 +4250,19 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
     if seed is not None:
         if not isinstance(seed, int):
             raise Exception('seed (%s) must be None or an integer.' % str(seed))
+    
+    # Check that either filter_dict is provided, or both filter_name and photometric_system are provided
+    if (filter_dict is not None) and ((filter_name is not None) or (photometric_system is not None)):
+        raise Exception('Both filter_dict and either filter_name or photometric_system was provided. \n'\
+                        'Please provide either filter_dict or filter_name + photometric_system')
+        
+    if (filter_name is None) ^ (photometric_system is None):
+        raise Exception('Either filter_name or photometric_system was provided without the other. Please provide both')
 
     # Check to see that the filter dictionary, and red_law are valid
+    if (filter_name is not None) and (photometric_system is not None):
+        filter_dict = {}
+        filter_dict[photometric_system] = [filter_name] 
     for system in filter_dict:
         if system not in photometric_system_dict:
             exception_str = 'photometric_system must be a key in ' \
@@ -4274,7 +4294,7 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
                 raise Exception(exception_str)
 
 
-def refine_events(input_root, filter_dict, red_law,
+def refine_events(input_root, red_law, filter_dict = None, filter_name = None, photometric_system = None,
                   overwrite=False,
                   output_file='default', hdf5_file_comp=None, legacy = False, seed = None):
     """
@@ -4345,8 +4365,12 @@ def refine_events(input_root, filter_dict, red_law,
                         'Either delete the .fits file, or pick a new name.')
 
     # Error handling/complaining if input types are not right.
-    _check_refine_events(input_root, filter_dict, red_law,
+    _check_refine_events(input_root, filter_dict, filter_name, photometric_system, red_law,
                          overwrite, output_file, hdf5_file_comp, legacy, seed)
+    
+    if (filter_name is not None) & (photometric_system is not None):
+        filter_dict = {}
+        filter_dict[photometric_system] = [filter_name]
     
     filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filter_dict.items()])
     if output_file == 'default':

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4178,9 +4178,10 @@ def _convert_photometric_99_to_nan(table, photometric_system='ubv'):
             table[name][cond] = np.nan
 
 
-def _check_refine_events(input_root, filter_name,
-                         photometric_system, red_law, overwrite,
-                         output_file, hdf5_file_comp, legacy, seed):
+def _check_refine_events(input_root, red_law, overwrite,
+                         output_file, hdf5_file_comp, legacy, seed,
+                         filter_name = None, photometric_system = None
+                         filter_dict = None):
     """
     Checks that the inputs of refine_events are valid
 
@@ -4219,12 +4220,18 @@ def _check_refine_events(input_root, filter_name,
 
     if not isinstance(input_root, str):
         raise Exception('input_root (%s) must be a string.' % str(input_root))
+ 
+    if filter_name is not None:
+        if not isinstance(filter_name, str):
+            raise Exception('filter_name (%s) must be a string or list.' % str(filter_name))
 
-    if not isinstance(filter_name, str):
-        raise Exception('filter_name (%s) must be a string.' % str(filter_name))
-
-    if not isinstance(photometric_system, str):
-        raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))
+    if photometric_system is not None:
+        if not isinstance(photometric_system, str):
+            raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))
+    
+    if filter_dict is not None:
+        if not isinstance(filters_dict, dict):
+            raise Exception('filters_dict (%s) must be a dictionary.' % str(filters_dict))
 
     if not isinstance(red_law, str):
         raise Exception('red_law (%s) must be a string.' % str(red_law))
@@ -4246,25 +4253,48 @@ def _check_refine_events(input_root, filter_name,
         if not isinstance(seed, int):
             raise Exception('seed (%s) must be None or an integer.' % str(seed))
 
-    # Check to see that the filter name, photometric system, red_law are valid
-    if photometric_system not in photometric_system_dict:
-        exception_str = 'photometric_system must be a key in ' \
-                        'photometric_system_dict. \n' \
-                        'Acceptable values are : '
-        for photometric_system in photometric_system_dict:
-            exception_str += '%s, ' % photometric_system
-        exception_str = exception_str[:-2]
-        raise Exception(exception_str)
+    # Check to see that the filter name, photometric system, filter dictionary, and/or red_law are valid
+    if photometric_system is not None:
+        if photometric_system not in photometric_system_dict:
+            exception_str = 'photometric_system must be a key in ' \
+                            'photometric_system_dict. \n' \
+                            'Acceptable values are : '
+            for photometric_system in photometric_system_dict:
+                exception_str += '%s, ' % photometric_system
+            exception_str = exception_str[:-2]
+            raise Exception(exception_str)
+            
+    if filter_name is not None:
+        if filter_name not in photometric_system_dict[photometric_system]:
+            exception_str = 'filter_name must be a value in ' \
+                            'photometric_system_dict[%s]. \n' \
+                            'Acceptable values are : ' % photometric_system
+            for filter_name in photometric_system_dict[photometric_system]:
+                exception_str += '%s, ' % filter_name
+            exception_str = exception_str[:-2]
+            raise Exception(exception_str)
+            
+    if filter_dict is not None:
+        for system in filters_dict:
+            if system not in photometric_system_dict:
+                exception_str = 'photometric_system must be a key in ' \
+                                'photometric_system_dict. \n' \
+                                'Acceptable values are : '
+                for photometric_system in photometric_system_dict:
+                    exception_str += '%s, ' % photometric_system
+                exception_str = exception_str[:-2]
+                raise Exception(exception_str)
 
-    if filter_name not in photometric_system_dict[photometric_system]:
-        exception_str = 'filter_name must be a value in ' \
-                        'photometric_system_dict[%s]. \n' \
-                        'Acceptable values are : ' % photometric_system
-        for filter_name in photometric_system_dict[photometric_system]:
-            exception_str += '%s, ' % filter_name
-        exception_str = exception_str[:-2]
-        raise Exception(exception_str)
-
+            for filt in filters_dict[system]:
+                if filt not in photometric_system_dict[system]:
+                    exception_str = 'filter_name must be a value in ' \
+                                    'photometric_system_dict[%s]. \n' \
+                                    'Acceptable values are : ' % system
+                    for filter_name in photometric_system_dict[system]:
+                        exception_str += '%s, ' % filter_name
+                    exception_str = exception_str[:-2]
+                    raise Exception(exception_str)
+            
     key = photometric_system + '_' + filter_name
     if red_law not in filt_dict[key]:
         exception_str = 'red_law must be a value in ' \

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4178,8 +4178,8 @@ def _convert_photometric_99_to_nan(table, photometric_system='ubv'):
             table[name][cond] = np.nan
 
 
-def _check_refine_events(input_root,filter_dict, filter_name, photometric_system, red_law, overwrite,
-                         output_file, hdf5_file_comp, legacy, seed):
+def _check_refine_events(input_root,filter_dict, red_law, overwrite, output_file, 
+                         hdf5_file_comp, legacy, seed, filter_name=None, photometric_system=None):
     """
     Checks that the inputs of refine_events are valid
 
@@ -4188,14 +4188,14 @@ def _check_refine_events(input_root,filter_dict, filter_name, photometric_system
     input_root : str
         The root path and name of the *_events.fits and *_blends.fits.
         Don't include those suffixes yet.
-
-    filter_name : str
-        The name of the filter in which to calculate all the
-        microlensing events. The filter name convention is set
-        in the global filt_dict parameter at the top of this module.
-
-    photometric_system : str
-        The name of the photometric system in which the filter exists.
+        
+    filter_dict : dict
+        Dictionary with desired photometric systems and filters to calculate microlensing events for.
+        The dictionary keys are photometric systems.
+        The dictionary values are lists of strings filled with filters within that photometric system key.
+        Example:
+            To calculate the events for UBV U, and ZTF, u, g, r: 
+                filter_dict = {'ubv':['U'],'ztf':['u','g','r']}
 
     red_law : str
         The name of the reddening law to use from SPISEA.
@@ -4214,6 +4214,14 @@ def _check_refine_events(input_root,filter_dict, filter_name, photometric_system
     seed : None or int
         If not None, this forces the random orbit time for binaries to be fixed every time.
         If seed is added but there are no binaries, the seed will have no consequence.
+        
+    filter_name : str, optional, DEPRECATED
+        The name of the filter in which to calculate all the
+        microlensing events. The filter name convention is set
+        in the global filt_dict parameter at the top of this module.
+
+    photometric_system : str, optional, DEPRECATED
+        The name of the photometric system in which the filter exists.
     """
 
     if not isinstance(input_root, str):
@@ -4222,6 +4230,10 @@ def _check_refine_events(input_root,filter_dict, filter_name, photometric_system
     if filter_dict is not None:
         if not isinstance(filter_dict, dict):
             raise Exception('filter_dict (%s) must be a dictionary.' % str(filter_dict))
+        if not all(isinstance(key,str) for key in filter_dict):
+            raise Exception('All filter_dict keys must be strings.')
+        if not all(isinstance(filt,str) for key,val in filter_dict.items() for filt in val):
+            raise Exception('All filter_dict vaues must be lists of strings.')
         
     if filter_name is not None:
         if not isinstance(filter_name, str):
@@ -4252,6 +4264,9 @@ def _check_refine_events(input_root,filter_dict, filter_name, photometric_system
             raise Exception('seed (%s) must be None or an integer.' % str(seed))
     
     # Check that either filter_dict is provided, or both filter_name and photometric_system are provided
+    if filter_dict is None and ((filter_name is None) or (photometric_system is None)):
+        raise Exception('Either filter_dict or filter_name + photometric_system must be provided.')
+        
     if (filter_dict is not None) and ((filter_name is not None) or (photometric_system is not None)):
         raise Exception('Both filter_dict and either filter_name or photometric_system was provided. \n'\
                         'Please provide either filter_dict or filter_name + photometric_system')
@@ -4295,8 +4310,7 @@ def _check_refine_events(input_root,filter_dict, filter_name, photometric_system
 
 
 def refine_events(input_root, red_law, filter_dict = None, filter_name = None, photometric_system = None,
-                  overwrite=False,
-                  output_file='default', hdf5_file_comp=None, legacy = False, seed = None):
+                  overwrite=False, output_file='default', hdf5_file_comp=None, legacy = False, seed = None):
     """
     Takes the output Astropy table from calc_events, and from that
     calculates the time of closest approach. Will also return source-lens
@@ -4308,14 +4322,14 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
         The root path and name of the \*_events.fits, \*_blends.fits,
         \*_galaxia_params.txt, \*_calc_events.log, and \_*_perform_pop_syn.log.
         Don't include those suffixes yet.
-
-    filter_name : str
-        The name of the filter in which to calculate all the
-        microlensing events. The filter name convention is set
-        in the global filt_dict parameter at the top of this module.
-
-    photometric_system : str
-        The name of the photometric system in which the filter exists.
+        
+    filter_dict : dict
+        Dictionary with desired photometric systems and filters to calculate microlensing events for.
+        The dictionary keys are photometric systems.
+        The dictionary values are lists of strings filled with filters within that photometric system key.
+        Example:
+            To calculate the events for UBV U, and ZTF, u, g, r: 
+                filter_dict = {'ubv':['U'],'ztf':['u','g','r']}
 
     red_law : str
         The name of the reddening law to use from SPISEA.
@@ -4343,6 +4357,14 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
         If not None, this forces the random orbit time for binaries to be fixed every time.
         If seed is added but there are no binaries, the seed will have no consequence.
         Default is None.
+    
+    filter_name : str, optional, DEPRECATED
+        The name of the filter in which to calculate all the
+        microlensing events. The filter name convention is set
+        in the global filt_dict parameter at the top of this module.
+
+    photometric_system : str, optional, DEPRECATED
+        The name of the photometric system in which the filter exists.
 
     Returns
     -------
@@ -4365,12 +4387,11 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
                         'Either delete the .fits file, or pick a new name.')
 
     # Error handling/complaining if input types are not right.
-    _check_refine_events(input_root, filter_dict, filter_name, photometric_system, red_law,
-                         overwrite, output_file, hdf5_file_comp, legacy, seed)
+    _check_refine_events(input_root, filter_dict, red_law, overwrite, output_file, hdf5_file_comp,
+                         legacy, seed, filter_name=filter_name, photometric_system=photometric_system)
     
     if (filter_name is not None) & (photometric_system is not None):
-        filter_dict = {}
-        filter_dict[photometric_system] = [filter_name]
+        filter_dict = {photometric_system:[filter_name]}
     
     filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filter_dict.items()])
     if output_file == 'default':
@@ -5226,7 +5247,7 @@ def _check_refine_binary_events(events, companions,
     photometric_system : str
         The name of the photometric system in which the filter exists.
     
-    filter_name : str
+    filter_name : str 
         The name of the filter in which to calculate all the
         microlensing events. The filter name convention is set
         in the global filt_dict parameter at the top of this module.
@@ -5263,11 +5284,11 @@ def _check_refine_binary_events(events, companions,
     if not isinstance(companions, str):
         raise Exception('companions (%s) must be a string.' % str(companions))
     
-    if not isinstance(photometric_system, str):
-        raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))
-    
     if not isinstance(filter_name, str):
-        raise Exception('filter_name (%s) must be a string.' % str(filter_name))
+        raise Exception('filter_name (%s) must be a string.' % str(filter_name))        
+
+    if not isinstance(photometric_system, str):
+        raise Exception('photometric_system (%s) must be a string.' % str(photometric_system))  
 
     if not isinstance(output_file, str):
         raise Exception('output_file (%s) must be a string.' % str(output_file))
@@ -5304,7 +5325,7 @@ def _check_refine_binary_events(events, companions,
     if filter_name not in photometric_system_dict[photometric_system]:
         exception_str = 'filter_name must be a value in ' \
                         'photometric_system_dict[%s]. \n' \
-                        'Acceptable values are : ' % photometric_system
+                        'Acceptable values are : ' % system
         for filter_name in photometric_system_dict[photometric_system]:
             exception_str += '%s, ' % filter_name
         exception_str = exception_str[:-2]
@@ -5328,7 +5349,7 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
     companions : str
         fits file containing the companions calculated from refine_events
     
-    photometric_system : str
+    photometric_system : str 
         The name of the photometric system in which the filter exists.
     
     filter_name : str
@@ -5407,7 +5428,7 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
 
     event_table['f_blend_%s' % filter_name] = event_table['f_blend_%s' % filter_name] # None of these should be nan
     if type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == np.ma.core.MaskedArray or type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == MaskedColumn:
-        comp_table['m_%s_%s' % (photometric_system, filter_name)] = comp_table['m_%s_%s' % (photometric_system, filter_name)].filled(np.nan)
+            comp_table['m_%s_%s' % (photometric_system, filter_name)] = comp_table['m_%s_%s' % (photometric_system, filter_name)].filled(np.nan) 
     
     event_table.add_column( Column(np.zeros(len(event_table), dtype=float), name='n_peaks') )
     event_table.add_column( Column(np.zeros(len(event_table), dtype=float), name='bin_delta_m') )
@@ -5453,13 +5474,14 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
     event_table_df['companion_idx_list'] = empty_lists
     
     inputs = np.empty(multiples_lightcurves, dtype = object)
+    
     for i in range(len(grouped_comps.groups)):
         obj_id_L = grouped_comps.groups.keys[i][0]
         obj_id_S = grouped_comps.groups.keys[i][1]
         obj_id_L_S = (obj_id_L, obj_id_S)
         event_table_df['companion_idx_list'].loc[obj_id_L_S] = list(grouped_comps.groups[i]['companion_idx'])
         inputs[i] = [[event_table_df.loc[obj_id_L_S]], grouped_comps.groups[i].to_pandas(), obj_id_L, obj_id_S, 
-                     photometric_system, filter_name, red_law, save_phot, phot_dir, overwrite]
+                     photometric_system, filter_name, red_law, save_phot, phot_dir, overwrite] 
     
     if multi_proc:
         results = pool.starmap(one_lightcurve_analysis, inputs)

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -5428,7 +5428,7 @@ def refine_binary_events(events, companions, photometric_system, filter_name,
 
     event_table['f_blend_%s' % filter_name] = event_table['f_blend_%s' % filter_name] # None of these should be nan
     if type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == np.ma.core.MaskedArray or type(comp_table['m_%s_%s' % (photometric_system, filter_name)]) == MaskedColumn:
-            comp_table['m_%s_%s' % (photometric_system, filter_name)] = comp_table['m_%s_%s' % (photometric_system, filter_name)].filled(np.nan) 
+        comp_table['m_%s_%s' % (photometric_system, filter_name)] = comp_table['m_%s_%s' % (photometric_system, filter_name)].filled(np.nan) 
     
     event_table.add_column( Column(np.zeros(len(event_table), dtype=float), name='n_peaks') )
     event_table.add_column( Column(np.zeros(len(event_table), dtype=float), name='bin_delta_m') )

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4219,8 +4219,8 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
     if not isinstance(input_root, str):
         raise Exception('input_root (%s) must be a string.' % str(input_root))
     
-    if not isinstance(filters_dict, dict):
-        raise Exception('filters_dict (%s) must be a dictionary.' % str(filters_dict))
+    if not isinstance(filter_dict, dict):
+        raise Exception('filter_dict (%s) must be a dictionary.' % str(filter_dict))
 
     if not isinstance(red_law, str):
         raise Exception('red_law (%s) must be a string.' % str(red_law))
@@ -4243,7 +4243,7 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
             raise Exception('seed (%s) must be None or an integer.' % str(seed))
 
     # Check to see that the filter dictionary, and red_law are valid
-    for system in filters_dict:
+    for system in filter_dict:
         if system not in photometric_system_dict:
             exception_str = 'photometric_system must be a key in ' \
                             'photometric_system_dict. \n' \
@@ -4253,7 +4253,7 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
             exception_str = exception_str[:-2]
             raise Exception(exception_str)
 
-        for filt in filters_dict[system]:
+        for filt in filter_dict[system]:
             if filt not in photometric_system_dict[system]:
                 exception_str = 'filter_name must be a value in ' \
                                 'photometric_system_dict[%s]. \n' \
@@ -4263,15 +4263,15 @@ def _check_refine_events(input_root,filter_dict, red_law, overwrite,
                 exception_str = exception_str[:-2]
                 raise Exception(exception_str)
             
-    key = photometric_system + '_' + filter_name
-    if red_law not in filt_dict[key]:
-        exception_str = 'red_law must be a value in ' \
-                        'filt_dict[%s]. \n' \
-                        'Acceptable values are : ' % key
-        for red_law in filt_dict[key]:
-            exception_str += '%s, ' % red_law
-        exception_str = exception_str[:-2]
-        raise Exception(exception_str)
+            key = system + '_' + filt
+            if red_law not in filt_dict[key]:
+                exception_str = 'red_law must be a value in ' \
+                                'filt_dict[%s]. \n' \
+                                'Acceptable values are : ' % key
+                for red_law in filt_dict[key]:
+                    exception_str += '%s, ' % red_law
+                exception_str = exception_str[:-2]
+                raise Exception(exception_str)
 
 
 def refine_events(input_root, filter_dict, red_law,
@@ -4348,10 +4348,10 @@ def refine_events(input_root, filter_dict, red_law,
     _check_refine_events(input_root, filter_dict, red_law,
                          overwrite, output_file, hdf5_file_comp, legacy, seed)
     
-    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filters_dict.items()])
+    filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filter_dict.items()])
     if output_file == 'default':
         output_file = '{0:s}_refined_events_{1:s}_{2:s}.fits'.format(input_root, 
-                                                                     output_filters_string,
+                                                                     filters_string,
                                                                      red_law)
 
     t_0 = time.time()
@@ -4384,15 +4384,15 @@ def refine_events(input_root, filter_dict, red_law,
         
 
     # If photometric fields contain -99, convert to nan
-    photometric_system = filters_dict.keys()
-    filter_name = filters_dict.values()
+    photometric_system = filter_dict.keys()
+    filter_name = filter_dict.values()
     for system in photometric_system:
-        _convert_photometric_99_to_nan(event_tab, photometric_system)
-        _convert_photometric_99_to_nan(blend_tab, photometric_system)
+        _convert_photometric_99_to_nan(event_tab, system)
+        _convert_photometric_99_to_nan(blend_tab, system)
 
     # Only keep events with luminous sources
-    for system in filters_dict:
-        for filters in filters_dict[system]:
+    for system in filter_dict:
+        for filters in filter_dict[system]:
             event_tab = event_tab[~np.isnan(event_tab[system + '_' + filters + '_S'])]
 
     # Grab the obs_time from the calc_events log
@@ -4602,7 +4602,7 @@ def refine_events(input_root, filter_dict, red_law,
 
     line0 = 'FUNCTION INPUT PARAMETERS' + '\n'
     line1 = 'input_root : ' + input_root + '\n'
-    line2 = 'filter_dict : ' + ', '.join([': '.join([system, ', '.join(filts)]) for system , filts in filters_dict.items()]) + '\n'
+    line2 = 'filter_dict : ' + ', '.join([': '.join([system, ', '.join(filts)]) for system , filts in filter_dict.items()]) + '\n'
     line3 = 'red_law : ' + red_law + '\n'
 
     line4 = 'VERSION INFORMATION' + '\n'
@@ -4623,13 +4623,12 @@ def refine_events(input_root, filter_dict, red_law,
         if len(companion_table) > 0:
             line14 = output_file[:-5] + "_companions.fits" + ' : companions refined events'
     
-    for system in filter_dict:
-        for filters in filter_dict[system]:
-            with open(input_root + '_refined_events_' + system + '_' + filters + '_' + red_law + '.log', 'w') as out:
-                out.writelines([line0, dash_line, line1, line2, line3, empty_line,
-                                line4, dash_line, line5, line6, line7, empty_line,
-                                line8, dash_line, line9, line10, line11, empty_line,
-                                line12, dash_line, line13, line14])
+
+    with open(input_root + '_refined_events_' + filters_string + '_' + red_law + '.log', 'w') as out:
+        out.writelines([line0, dash_line, line1, line2, line3, empty_line,
+                        line4, dash_line, line5, line6, line7, empty_line,
+                        line8, dash_line, line9, line10, line11, empty_line,
+                        line12, dash_line, line13, line14])
 
     print('refine_events runtime : {0:f} s'.format(t_1 - t_0))
     return

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -5325,7 +5325,7 @@ def _check_refine_binary_events(events, companions,
     if filter_name not in photometric_system_dict[photometric_system]:
         exception_str = 'filter_name must be a value in ' \
                         'photometric_system_dict[%s]. \n' \
-                        'Acceptable values are : ' % system
+                        'Acceptable values are : ' % photometric_system
         for filter_name in photometric_system_dict[photometric_system]:
             exception_str += '%s, ' % filter_name
         exception_str = exception_str[:-2]

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -4399,7 +4399,7 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
     if output_file == 'default':
         system = list(filter_dict.keys())[0]
         filt = filter_dict[system][0]
-        if len(filter_dict) == 1 and len(filter_dict[system]) == 1: 
+        if len(filter_dict) == 1 and len(filter_dict[system]) == 1:
             output_file = '{0:s}_refined_events_{1:s}_{2:s}_{3:s}.fits'.format(input_root, 
                                                                                system,
                                                                                filt,
@@ -4538,7 +4538,7 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
         filters_string = ', '.join([': '.join([system, ', '.join(filts)]) for system , filts in filter_dict.items()])
         with fits.open(output_file, mode='update') as hdul:
             header = hdul[0].header
-            header['filter_dict'] = filters_string
+            header['filters'] = filters_string
     
     
 
@@ -4676,14 +4676,19 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
     line11 = str(N_events_survey) + ' : candidate events in survey window' + '\n'
 
     line12 = 'FILES CREATED' + '\n'
-    line13 = output_file + ' : refined events'
+    line13 = output_file + ' : refined events' + '\n'
     line14 = '\n' #By default no companion file created
     
     if hdf5_file_comp is not None:
         if len(companion_table) > 0:
             line14 = output_file[:-5] + "_companions.fits" + ' : companions refined events'
     
-
+    system = list(filter_dict.keys())[0]
+    filt = filter_dict[system][0]
+    if len(filter_dict) == 1 and len(filter_dict[system]) == 1:
+        filter_string = system + '_' + filt
+    else:
+        filter_string = 'multi_filt'
     with open(input_root + '_refined_events_' + filters_string + '_' + red_law + '.log', 'w') as out:
         out.writelines([line0, dash_line, line1, line2, line3, empty_line,
                         line4, dash_line, line5, line6, line7, empty_line,

--- a/popsycle/synthetic.py
+++ b/popsycle/synthetic.py
@@ -50,6 +50,7 @@ from operator import itemgetter
 from popsycle import binary_utils
 from astropy.io import fits
 from astropy.coordinates import solar_system_ephemeris
+from warnings import warn
 
 # Use builtin ephemris for popsycle
 solar_system_ephemeris.set('builtin')
@@ -4391,6 +4392,7 @@ def refine_events(input_root, red_law, filter_dict = None, filter_name = None, p
                          legacy, seed, filter_name=filter_name, photometric_system=photometric_system)
     
     if (filter_name is not None) & (photometric_system is not None):
+        warn('filter_name and photometric_system are deprecated, please use filter_dict', DeprecationWarning, stacklevel=2)
         filter_dict = {photometric_system:[filter_name]}
     
     filters_string = '_'.join(['_'.join([system, '_'.join(filts)]) for system , filts in filter_dict.items()])

--- a/popsycle/tests/test_synthetic.py
+++ b/popsycle/tests/test_synthetic.py
@@ -137,8 +137,7 @@ def srun_refine_events(srun_calc_events):
     input_root = srun_calc_events
 
     synthetic.refine_events(input_root=input_root,
-                            filter_name='I',
-                            photometric_system='ubv',
+                            filter_dict={'ubv':['I']},
                             red_law='Damineli16',
                             overwrite=True,
                             output_file='default')
@@ -235,8 +234,7 @@ def mrun_refine_events(mrun_calc_events):
     input_root = mrun_calc_events
 
     synthetic.refine_events(input_root=input_root,
-                            filter_name='I',
-                            photometric_system='ubv',
+                            filter_dict={'ubv':['I']},
                             red_law='Damineli16',
                             hdf5_file_comp=input_root + '_companions.h5',
                             overwrite=True,


### PR DESCRIPTION
Added multiband capabilities to refine_events

synthetic.py
- refine_events 
  - filter_dict loops through each key and value of the dictionary
- check_refine_events
  - Checks that filter_dict is in correct format
  - Checks that filter_name and photometric_system are not defined while filter_dict is defined
  - Checks that either filter_dict or both filter_name and photometric_system are provided
  - Checks that if using filter_name + photometric_system, both must be provided
run.py 
- refine_events
  - Each instance of refine_events is changed such that they use the dictionary to operate
  - All file outputs are changed so that the names of the file still match the old version using filter_dict
  - If skip_refine_binary_events is false, filter_dict gets split up into photometric_system and filter_name for refine_binary events ONLY
  - run.py will use the first filter in the dictionary to run refine_binary_events
Ran test_synthetic.py
Updated tutorials to take filter_dict for refine_events


